### PR TITLE
Truncate titles to 250 characters

### DIFF
--- a/src/notes.ts
+++ b/src/notes.ts
@@ -78,7 +78,7 @@ async function fileForArticle(
     vault: Vault,
     folder: string,
 ): Promise<TFile | null> {
-    const name = article.title.replace(/[\\/:]/gm, '');
+    const name = article.title.replace(/[\\/:]/gm, '').substring(0, 250);
     const notePath = normalizePath(path.join(folder, name + '.md'))
     const abstractFile = vault.getAbstractFileByPath(notePath);
 


### PR DESCRIPTION
Most file systems limit filenames to 255 characters. Trying to use a longer name results in ENAMETOOLONG.

250 is a long-enough value that also gives us room for the `.md` file extension.