### PR TITLE
Improve notes sync error handling

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -110,11 +110,19 @@ export default class InstapaperPlugin extends Plugin {
 			return 0;
 		}
 
-		this.log(`Synchronizing notes (${reason})`);
 		this.notesSyncInProgress = true;
-		const { cursor, count } = await syncNotes(this, token, this.settings.notesCursor);
-		await this.saveSettings({ notesCursor: cursor });
-		this.notesSyncInProgress = false;
+		this.log(`Synchronizing notes (${reason})`);
+		let count = 0;
+
+		try {
+			let cursor;
+			({ cursor, count } = await syncNotes(this, token, this.settings.notesCursor));
+			await this.saveSettings({ notesCursor: cursor });
+		} catch (e) {
+			this.log('Notes sync failure:', e);
+		} finally {
+			this.notesSyncInProgress = false;
+		}
 
 		return count;
 	}


### PR DESCRIPTION
We no longer persist the sync cursor if the sync encounters an error. This feels safer than the previous approach of always updating the cursor.

We also ensure that the "notes sync in progress" is cleared after the sync completes (for both successes and failures).