### PR TITLE
Add "Save to Instapaper" to URL-based menus

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This is the official Instapaper plugin for [Obsidian](https://obsidian.md).
 
 It integrates with your Instapaper account and allows you to:
 
+- Save URLs from Obsidian notes to your Instapaper account
 - Sync your highlights and notes to your Obsidian vault
 
 ## Setup

--- a/src/api.ts
+++ b/src/api.ts
@@ -119,6 +119,28 @@ export class InstapaperAPI {
         return data[0];
     }
 
+    async addBookmark(
+        token: InstapaperAccessToken,
+        data: {
+            url: string,
+            title?: string,
+            description?: string,
+            folder_id?: number,
+        },
+    ): Promise<InstapaperBookmark> {
+        const response = await this.fetch(
+            {
+                url: `${this.options.baseURL}/1.1/bookmarks/add`,
+                method: 'POST',
+                data: data,
+            },
+            token,
+        );
+
+        const bookmarks = await response.json as [InstapaperBookmark]
+        return bookmarks[0];
+    }
+
     async getHighlights(
         token: InstapaperAccessToken,
         data?: {

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,27 @@ export default class InstapaperPlugin extends Plugin {
 		await this.loadSettings();
 		this.addSettingTab(new InstapaperSettingTab(this.app, this));
 
+		this.registerEvent(
+			this.app.workspace.on('url-menu', (menu, url) => {
+				const token = this.settings.token;
+				if (!token) return;
+
+				menu.addItem((item) => {
+					item
+						.setTitle("Save to Instapaper")
+						.setIcon("bookmark-plus")
+						.onClick(async () => {
+							try {
+								const bookmark = await this.api.addBookmark(token, { url })
+								this.notice(`Saved "${bookmark.title}" to Instapaper`);
+							} catch (e) {
+								this.log('failed to add bookmark:', e);
+							}
+						});
+				});
+			})
+		);
+
 		this.addCommand({
 			id: 'sync',
 			name: 'Sync',

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,6 +33,7 @@ export default class InstapaperPlugin extends Plugin {
 								const bookmark = await this.api.addBookmark(token, { url })
 								this.notice(`Saved "${bookmark.title}" to Instapaper`);
 							} catch (e) {
+								this.notice(`Unable to save to Instapaper`);
 								this.log('failed to add bookmark:', e);
 							}
 						});


### PR DESCRIPTION
We now offer a "Save to Instapaper" menu item for URL-based context menus when an Instapaper account is connected.