### PR TITLE
Change link symbol to NORTH EAST ARROW

### DIFF
--- a/src/notes.ts
+++ b/src/notes.ts
@@ -2,7 +2,7 @@ import { TFile, Vault, normalizePath } from "obsidian";
 import type InstapaperPlugin from "./main";
 import type { InstapaperAccessToken, InstapaperBookmark, InstapaperHighlight } from "./api";
 
-const linkSymbol = '§'; // '↗'; // '↪';
+const linkSymbol = '↗';
 
 export async function syncNotes(
     plugin: InstapaperPlugin,


### PR DESCRIPTION
This looks a little nicer than the previous "section sign" symbol.