### PR TITLE
Don't send body data with GET requests

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -70,15 +70,21 @@ export class InstapaperAPI {
         const authorization = this.oauth.authorize(request, token);
 
         let url = request.url;
-        if (request.data && request.method == 'GET') {
-            url += '?' + new URLSearchParams(request.data).toString();
+        let body: string | undefined = undefined;
+
+        if (request.data) {
+            if (request.method == 'GET') {
+                url += '?' + new URLSearchParams(request.data).toString();
+            } else {
+                body = new URLSearchParams(request.data).toString();
+            }
         }
 
         return await requestUrl({
             url: url,
             method: request.method,
             contentType: "application/x-www-form-urlencoded",
-            body: request.data ? new URLSearchParams(request.data).toString() : undefined,
+            body: body,
             headers: { ...this.oauth.toHeader(authorization) },
             throw: true,
         });

--- a/src/api.ts
+++ b/src/api.ts
@@ -70,20 +70,22 @@ export class InstapaperAPI {
         const authorization = this.oauth.authorize(request, token);
 
         let url = request.url;
-        let body: string | undefined = undefined;
+        let body: string | undefined;
+        let contentType: string | undefined;
 
         if (request.data) {
             if (request.method == 'GET') {
                 url += '?' + new URLSearchParams(request.data).toString();
             } else {
                 body = new URLSearchParams(request.data).toString();
+                contentType = "application/x-www-form-urlencoded";
             }
         }
 
         return await requestUrl({
             url: url,
             method: request.method,
-            contentType: "application/x-www-form-urlencoded",
+            contentType: contentType,
             body: body,
             headers: { ...this.oauth.toHeader(authorization) },
             throw: true,


### PR DESCRIPTION
This was an oversight in the previous request-building logic. We would correctly move the request parameters to a GET request's query string, but they were also being sent in the request's body.