### PR TITLE
Update to Node.js 18

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [16.x]
+        node-version: [18.x]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Node.js ${{ matrix.node-version }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
 				"oauth-1.0a": "^2.2.6"
 			},
 			"devDependencies": {
-				"@types/node": "^16.11.6",
+				"@types/node": "^18.19.32",
 				"@typescript-eslint/eslint-plugin": "7.6.0",
 				"@typescript-eslint/parser": "7.6.0",
 				"builtin-modules": "3.3.0",
@@ -620,10 +620,13 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "16.18.68",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.68.tgz",
-			"integrity": "sha512-sG3hPIQwJLoewrN7cr0dwEy+yF5nD4D/4FxtQpFciRD/xwUzgD+G05uxZHv5mhfXo4F9Jkp13jjn0CC2q325sg==",
-			"dev": true
+			"version": "18.19.32",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.32.tgz",
+			"integrity": "sha512-2bkg93YBSDKk8DLmmHnmj/Rwr18TLx7/n+I23BigFwgexUJoMHZOd8X1OFxuF/W3NN0S2W2E5sVabI5CPinNvA==",
+			"dev": true,
+			"dependencies": {
+				"undici-types": "~5.26.4"
+			}
 		},
 		"node_modules/@types/semver": {
 			"version": "7.5.8",
@@ -2218,6 +2221,12 @@
 			"engines": {
 				"node": ">=14.17"
 			}
+		},
+		"node_modules/undici-types": {
+			"version": "5.26.5",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+			"dev": true
 		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 	"author": "Instapaper",
 	"license": "MIT",
 	"devDependencies": {
-		"@types/node": "^16.11.6",
+		"@types/node": "^18.19.32",
 		"@typescript-eslint/eslint-plugin": "7.6.0",
 		"@typescript-eslint/parser": "7.6.0",
 		"builtin-modules": "3.3.0",


### PR DESCRIPTION
This is primarily for the development environment because our releases need to run non-Node.js environments (i.e. WebKit for iOS). This upgrade will allow us to use some more recent build tooling and packages.