### PR TITLE
Replace Windows special characters with empty string

### DIFF
--- a/src/notes.ts
+++ b/src/notes.ts
@@ -76,7 +76,7 @@ async function fileForArticle(
     vault: Vault,
     folder: string,
 ): Promise<TFile | null> {
-    const name = article.title.replace(/[\\/:]/gm, '').substring(0, 250);
+    const name = article.title.replace(/[\\/:<>?|*]/gm, '').substring(0, 250);
     const path = normalizePath(`${folder}/${name}.md`);
     const file = vault.getFileByPath(path);
 


### PR DESCRIPTION
Some Windows users report syncing not working properly.

```
> str = "\asdf|*\"\\/<>:?|asdf"
'asdf|*"\\/<>:?|asdf'
> str.replace(/[\\/<>?|:*"]/gm, '')
'asdfasdf'
```