### PR TITLE
Disable console logging in production builds

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -41,6 +41,7 @@ const context = await esbuild.context({
 	outfile: "main.js",
 	minify: prod,
 	define: {
+		'process.env.INSTAPAPER_DEBUG': JSON.stringify(process.env['INSTAPAPER_DEBUG'] ?? !prod),
 		'process.env.INSTAPAPER_CONSUMER_KEY': JSON.stringify(process.env['INSTAPAPER_CONSUMER_KEY']),
 		'process.env.INSTAPAPER_CONSUMER_SECRET': JSON.stringify(process.env['INSTAPAPER_CONSUMER_SECRET']),
 	},

--- a/src/main.ts
+++ b/src/main.ts
@@ -84,7 +84,9 @@ export default class InstapaperPlugin extends Plugin {
 	}
 
 	log(message: string, ...args: unknown[]): void {
-		console.log('[instapaper] ' + message, ...args);
+		if (process.env.INSTAPAPER_DEBUG) {
+			console.log('[instapaper] ' + message, ...args);
+		}
 	}
 
 	notice(message: string): Notice {


### PR DESCRIPTION
Console logging is still enabled in development builds or when the INSTAPAPER_DEBUG environment variable is set at build time.