### PR TITLE
Replace spaces with hyphens in tag names

### DIFF
--- a/src/notes.ts
+++ b/src/notes.ts
@@ -57,7 +57,8 @@ export async function syncNotes(
                 frontmatter['url'] = article.url;
                 frontmatter['date'] = formatTimestamp(article.time);
                 frontmatter['tags'] = (article.tags.length > 0)
-                    ? article.tags.map((tag) => tag.name) : undefined;
+                    ? article.tags.map((tag) => tag.name.replace(/\s+/, '-'))
+                    : undefined;
                 if (article.pubtime) {
                     frontmatter['pubdate'] = formatTimestamp(article.pubtime);
                 }


### PR DESCRIPTION
Obsidian tags cannot contain spaces so we need to replace them with a supported character. We use the hyphen.

https://help.obsidian.md/Editing+and+formatting/Tags#Tag+format