### PR TITLE
Support "deep" default settings merges

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"hmacsha1": "^1.0.0",
+				"merge-options": "^3.0.4",
 				"oauth-1.0a": "^2.2.6"
 			},
 			"devDependencies": {
@@ -1676,6 +1677,15 @@
 				"node": ">=0.12.0"
 			}
 		},
+		"node_modules/is-plain-obj": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+			"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -1758,6 +1768,18 @@
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true
+		},
+		"node_modules/merge-options": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+			"integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+			"license": "MIT",
+			"dependencies": {
+				"is-plain-obj": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
 		},
 		"node_modules/merge2": {
 			"version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 	},
 	"dependencies": {
 		"hmacsha1": "^1.0.0",
+		"merge-options": "^3.0.4",
 		"oauth-1.0a": "^2.2.6"
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { Notice, Plugin, TFolder } from 'obsidian';
 import { InstapaperAccount, InstapaperAPI } from './api'
 import { DEFAULT_SETTINGS, InstapaperPluginSettings, InstapaperSettingTab } from './settings'
 import { syncNotes } from './notes';
+import mergeOptions from 'merge-options';
 
 type SyncResult = {
 	notes: number
@@ -128,7 +129,7 @@ export default class InstapaperPlugin extends Plugin {
 			needsSave = true;
 		}
 
-		this.settings = Object.assign({}, DEFAULT_SETTINGS, data);
+		this.settings = mergeOptions(DEFAULT_SETTINGS, data);
 		if (needsSave) {
 			await this.saveSettings();
 		}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -11,9 +11,7 @@ export interface InstapaperPluginSettings {
     notesCursor: number;
 }
 
-export const DEFAULT_SETTINGS: InstapaperPluginSettings = {
-    token: undefined,
-    account: undefined,
+export const DEFAULT_SETTINGS: Partial<InstapaperPluginSettings> = {
     syncFrequency: 0,
     syncOnStart: true,
     notesFolder: 'Instapaper Notes',


### PR DESCRIPTION
Object.assign() only performs a shallow merge, and in the future we will want to support deep (recursively-merged) default settings.

This isn't too difficult to write ourselves, but the merge-options already packages appears to do exactly what we want, so use it.