### PR TITLE
Downgrade to @types/node v16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 			},
 			"devDependencies": {
 				"@eslint/js": "^9.39.1",
-				"@types/node": "^18.19.32",
+				"@types/node": "^16.18.126",
 				"builtin-modules": "5.0.0",
 				"dotenv": "^17.2.2",
 				"esbuild": "0.27.0",
@@ -764,13 +764,11 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "18.19.32",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.32.tgz",
-			"integrity": "sha512-2bkg93YBSDKk8DLmmHnmj/Rwr18TLx7/n+I23BigFwgexUJoMHZOd8X1OFxuF/W3NN0S2W2E5sVabI5CPinNvA==",
+			"version": "16.18.126",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
+			"integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
 			"dev": true,
-			"dependencies": {
-				"undici-types": "~5.26.4"
-			}
+			"license": "MIT"
 		},
 		"node_modules/@types/tern": {
 			"version": "0.23.9",
@@ -2087,12 +2085,6 @@
 				"eslint": "^8.57.0 || ^9.0.0",
 				"typescript": ">=4.8.4 <6.0.0"
 			}
-		},
-		"node_modules/undici-types": {
-			"version": "5.26.5",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-			"dev": true
 		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 	"license": "MIT",
 	"devDependencies": {
 		"@eslint/js": "^9.39.1",
-		"@types/node": "^18.19.32",
+		"@types/node": "^16.18.126",
 		"builtin-modules": "5.0.0",
 		"dotenv": "^17.2.2",
 		"esbuild": "0.27.0",


### PR DESCRIPTION
This is more compatible with the Obsidian plugin ecosystem and avoids types mismatches with the Buffer API.