### PR TITLE
Add additional Obsidian API type definitions

### DIFF
--- a/src/types/obsidian.d.ts
+++ b/src/types/obsidian.d.ts
@@ -1,0 +1,5 @@
+// Type declarations to fix missing types in Obsidian definitions
+
+// Fix for missing Frontmatter type in obsidian.d.ts
+// This is a known issue with the Obsidian type definitions
+type Frontmatter = Record<string, unknown>;


### PR DESCRIPTION
The official obsidian.d.ts distribution is missing some types. We can add local definitions here.