### PR TITLE
Cast credential values as strings

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -16,9 +16,8 @@ export default class InstapaperPlugin extends Plugin {
 
 	async onload() {
 		this.api = new InstapaperAPI(
-			// @ts-expect-error
-			process.env.INSTAPAPER_CONSUMER_KEY,
-			process.env.INSTAPAPER_CONSUMER_SECRET,
+			process.env.INSTAPAPER_CONSUMER_KEY as string,
+			process.env.INSTAPAPER_CONSUMER_SECRET as string,
 		);
 
 		await this.loadSettings();


### PR DESCRIPTION
These values will also be available (based on our esbuild rules), and casting avoids the need for ts-expect-error.