### PR TITLE
Fall back to a default name if our title is empty

### DIFF
--- a/src/notes.ts
+++ b/src/notes.ts
@@ -94,7 +94,12 @@ async function fileForArticle(
     vault: Vault,
     folder: string,
 ): Promise<TFile> {
-    const name = article.title.replace(/[\\/:<>?|*"]/gm, '').substring(0, 250);
+    // Use a sanitized version of the article's title for our filename.
+    let name = article.title.replace(/[\\/:<>?|*"]/gm, '').substring(0, 250).trim();
+    if (!name) {
+        name = `Untitled-${article.bookmark_id}`;
+    }
+
     const path = normalizePath(`${folder}/${name}.md`);
     const file = vault.getFileByPath(path);
 


### PR DESCRIPTION
It's possible for our title-based name to be empty after our sanitation pass. In those cases, we'll use a generated "Untitled-..." name instead.