### PR TITLE
Add block identifiers to highlights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Block identifiers for highlights using Obsidian's block reference syntax (`^h{highlight_id}`). This enables linking to specific highlights and provides more robust duplicate detection.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ It integrates with your Instapaper account and allows you to:
 2. Enable the installed "Instapaper" plugin (**Settings → Community plugins → Installed plugins**).
 3. Click the "Options" icon (or go to **Settings → Instapaper**) to connect your Instapaper account, start syncing highlights, and manage other options.
 
+## Block Identifiers
+
+Each synced highlight includes a [block identifier](https://help.obsidian.md/Linking+notes+and+files/Internal+links#Link+to+a+block+in+a+note) using the format `^h{highlight_id}`. This allows you to link to specific highlights from other notes using `[[Article Name#^h123456]]` and reference highlights in queries and searches.
+
 ## Tags
 
 [Obsidian's tag format](https://help.obsidian.md/Editing+and+formatting/Tags#Tag+format) is more restrictive than Instapaper's so we apply some normalization rules:

--- a/src/notes.ts
+++ b/src/notes.ts
@@ -110,13 +110,20 @@ function linkForHighlight(highlight: InstapaperHighlight): string {
     return `https://www.instapaper.com/read/${highlight.article_id}/${highlight.highlight_id}`
 }
 
+// https://help.obsidian.md/links#Link+to+a+block+in+a+note
+function blockIdentifierForHighlight(highlight: InstapaperHighlight): string {
+    return `^h${highlight.highlight_id}`;
+}
+
 function hasHighlight(content: string, highlight: InstapaperHighlight): boolean {
-    return content.contains(linkForHighlight(highlight));
+    return content.contains(blockIdentifierForHighlight(highlight))
+        || content.contains(linkForHighlight(highlight));
 }
 
 function contentForHighlight(highlight: InstapaperHighlight): string {
     let content = highlight.text.replace(/^/gm, '> ');
     content += ` [${linkSymbol}](${linkForHighlight(highlight)})`;
+    content += ` ${blockIdentifierForHighlight(highlight)}`;
     content += "\n\n"
     if (highlight.note) {
         content += highlight.note + "\n\n";


### PR DESCRIPTION
Obsidian uses a `#^` Markdown link extension format to uniquely identify individual blocks. This also facilitates cross-note linking.

https://help.obsidian.md/links#Link+to+a+block+in+a+note

This approach is more Obsidian-native than our link-based identifiers, which we used for detecting existing highlights in a node.

Note that we're not exactly following the Obsidian convention of placing the block identifier _following_ the block quote because that would interfere with the placement of our user notes. I think that's a good compromise for our use case, but it's also something we can revisit.