### PR TITLE
Upgrade to v1.10.0 of the Obsidian API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Block identifiers for highlights using Obsidian's block reference syntax (`^h{highlight_id}`). This enables linking to specific highlights and provides more robust duplicate detection.
+
+### Changed
+
+- Minimum Obsidian version requirement updated to 1.10.0 for access to new API features.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ It integrates with your Instapaper account and allows you to:
 
 ## Setup
 
+This plugin requires Obsidian v1.10.0 or higher.
+
 1. Install the [Instapaper](https://obsidian.md/plugins?id=instapaper) plugin within Obsidian (**Settings → Community plugins**).
 2. Enable the installed "Instapaper" plugin (**Settings → Community plugins → Installed plugins**).
 3. Click the "Options" icon (or go to **Settings → Instapaper**) to connect your Instapaper account, start syncing highlights, and manage other options.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
 	"id": "instapaper",
 	"name": "Instapaper",
 	"version": "1.1.4",
-	"minAppVersion": "1.5.7",
+	"minAppVersion": "1.10.0",
 	"description": "Connect Obsidian to your Instapaper account.",
 	"author": "Instapaper",
 	"authorUrl": "https://www.instapaper.com",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
 				"dotenv": "^17.2.2",
 				"esbuild": "0.27.0",
 				"eslint": "^9.39.1",
-				"obsidian": "1.5.7",
+				"obsidian": "1.10.0",
 				"tslib": "2.8.0",
 				"typescript": "^5.9.2",
 				"typescript-eslint": "^8.50.0"
@@ -36,20 +36,26 @@
 			}
 		},
 		"node_modules/@codemirror/state": {
-			"version": "6.3.3",
-			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.3.3.tgz",
-			"integrity": "sha512-0wufKcTw2dEwEaADajjHf6hBy1sh3M6V0e+q4JKIhLuiMSe5td5HOWpUdvKth1fT1M9VYOboajoBHpkCd7PG7A==",
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.0.tgz",
+			"integrity": "sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==",
 			"dev": true,
-			"peer": true
-		},
-		"node_modules/@codemirror/view": {
-			"version": "6.22.3",
-			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.22.3.tgz",
-			"integrity": "sha512-rqnq+Zospwoi3x1vZ8BGV1MlRsaGljX+6qiGYmIpJ++M+LCC+wjfDaPklhwpWSgv7pr/qx29KiAKQBH5+DOn4w==",
-			"dev": true,
+			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@codemirror/state": "^6.1.4",
+				"@marijn/find-cluster-break": "^1.0.0"
+			}
+		},
+		"node_modules/@codemirror/view": {
+			"version": "6.38.1",
+			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.1.tgz",
+			"integrity": "sha512-RmTOkE7hRU3OVREqFVITWHz6ocgBjv08GoePscAakgVQfciA3SGCEk7mb9IzwW61cKKmlTpHXG6DUE5Ubx+MGQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@codemirror/state": "^6.5.0",
+				"crelt": "^1.0.6",
 				"style-mod": "^4.1.0",
 				"w3c-keyname": "^2.2.4"
 			}
@@ -740,6 +746,13 @@
 				"url": "https://github.com/sponsors/nzakas"
 			}
 		},
+		"node_modules/@marijn/find-cluster-break": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+			"integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/codemirror": {
 			"version": "5.60.8",
 			"resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.8.tgz",
@@ -1164,6 +1177,13 @@
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
 			"dev": true
+		},
+		"node_modules/crelt": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+			"integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
@@ -1800,17 +1820,18 @@
 			"integrity": "sha512-6bkxv3N4Gu5lty4viIcIAnq5GbxECviMBeKR3WX/q87SPQ8E8aursPZUtsXDnxCs787af09WPRBLqYrf/lwoYQ=="
 		},
 		"node_modules/obsidian": {
-			"version": "1.5.7",
-			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.5.7.tgz",
-			"integrity": "sha512-DNcvQJ6TvMflHZqWfO9cLGbOUbKTy2KBi6B6vjo5RG8XsftKZZq1zS/OQFhII2BnXK/DWan/lUcb2JYxfM3p5A==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.10.0.tgz",
+			"integrity": "sha512-F7hhnmGRQD1TanDPFT//LD3iKNUVd7N8sKL7flCCHRszfTxpDJ39j3T7LHbcGpyid906i6lD5oO+cnfLBzJMKw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/codemirror": "5.60.8",
 				"moment": "2.29.4"
 			},
 			"peerDependencies": {
-				"@codemirror/state": "^6.0.0",
-				"@codemirror/view": "^6.0.0"
+				"@codemirror/state": "6.5.0",
+				"@codemirror/view": "6.38.1"
 			}
 		},
 		"node_modules/optionator": {
@@ -1982,10 +2003,11 @@
 			}
 		},
 		"node_modules/style-mod": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.0.tgz",
-			"integrity": "sha512-Ca5ib8HrFn+f+0n4N4ScTIA9iTOQ7MaGS1ylHcoVqW9J7w2w8PzN6g9gKmTYgGEBH8e120+RCmhpje6jC5uGWA==",
-			"dev": true
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+			"integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
@@ -2100,7 +2122,8 @@
 			"version": "2.2.8",
 			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
 			"integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/which": {
 			"version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"dotenv": "^17.2.2",
 		"esbuild": "0.27.0",
 		"eslint": "^9.39.1",
-		"obsidian": "1.5.7",
+		"obsidian": "1.10.0",
 		"tslib": "2.8.0",
 		"typescript": "^5.9.2",
 		"typescript-eslint": "^8.50.0"


### PR DESCRIPTION
This version gives us access to the recommended new SettingGroup API, among other things.

Depending on those new APIs requires us to also bump our minAppVersion to Obsidian 1.10.0, which is relatively recent but widely available.