### PR TITLE
mergeOptions expects both arguments to be objects

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -136,7 +136,7 @@ export default class InstapaperPlugin extends Plugin {
 			needsSave = true;
 		}
 
-		this.settings = mergeOptions(DEFAULT_SETTINGS, data);
+		this.settings = mergeOptions(DEFAULT_SETTINGS, data ?? {});
 		if (needsSave) {
 			await this.saveSettings();
 		}


### PR DESCRIPTION
`data` is null on an initial installation with no prior settings.

Fixes #164