### PR TITLE
Clear the notes cursor on account disconnect

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -179,6 +179,7 @@ export default class InstapaperPlugin extends Plugin {
 		await this.saveSettings({
 			token: undefined,
 			account: undefined,
+			notesCursor: undefined,
 		});
 
 		this.clearSyncInterval();


### PR DESCRIPTION
This is user-specific state so clear it along with the token and account fields.

We still retain the actual sync'ed notes and their associated settings because we don't want to destroy anything in the user's vault.