### PR TITLE
Revise eslint grouping and ignore rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,14 +9,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
     groups:
       eslint:
+        applies-to: version-updates
         patterns:
           - '@eslint/*'
           - 'eslint'
           - 'typescript-eslint'
-        update-types:
-          - 'major'
+    ignore:
+      - dependency-name: "*eslint*"
+        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
A group's update-types rule controls which update types are included in the group, not which kinds of updates Dependabot will send for that group.

https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#groups--

Instead, revise the group definition and use a pattern-matching ignore rule to skip patch updates.

https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#ignore--

I may need to add more ignore rules for other packages because we were previously ignoring patch updates for all packages, but I did that primarily for eslint, so we'll see how it goes.