### PR TITLE
Add INSTAPAPER_BASE_URL build-time define

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -42,6 +42,7 @@ const context = await esbuild.context({
 	minify: prod,
 	define: {
 		'process.env.INSTAPAPER_DEBUG': JSON.stringify(process.env['INSTAPAPER_DEBUG'] ?? !prod),
+		'process.env.INSTAPAPER_BASE_URL': JSON.stringify(process.env['INSTAPAPER_BASE_URL'] ?? ''),
 		'process.env.INSTAPAPER_CONSUMER_KEY': JSON.stringify(process.env['INSTAPAPER_CONSUMER_KEY']),
 		'process.env.INSTAPAPER_CONSUMER_SECRET': JSON.stringify(process.env['INSTAPAPER_CONSUMER_SECRET']),
 	},

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ export default class InstapaperPlugin extends Plugin {
 		this.api = new InstapaperAPI(
 			process.env.INSTAPAPER_CONSUMER_KEY as string,
 			process.env.INSTAPAPER_CONSUMER_SECRET as string,
+			process.env.INSTAPAPER_BASE_URL ? { baseURL: process.env.INSTAPAPER_BASE_URL } : undefined,
 		);
 
 		await this.loadSettings();


### PR DESCRIPTION
Allow overriding the Instapaper base URL via an environment variable, useful for local development against a staging server.