### PR TITLE
Add a "Sync now" button to the Sync settings

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -263,7 +263,7 @@ export default class InstapaperPlugin extends Plugin {
 		this.registerInterval(this.syncInterval);
 	}
 
-	private reportSyncResult(result: SyncResult) {
+	reportSyncResult(result: SyncResult) {
 		const total = Object.values(result).reduce((a, b) => a + b);
 		switch (total) {
 			case 0:

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -144,6 +144,23 @@ export class InstapaperSettingTab extends PluginSettingTab {
                         await this.plugin.saveSettings({ syncFrequency: parseInt(value) });
                         await this.plugin.updateSyncInterval();
                     });
+                })
+                .addButton((button) => {
+                    button
+                        .setIcon('refresh-cw')
+                        .setTooltip('Sync now')
+                        .onClick(async () => {
+                            button.setDisabled(true);
+                            try {
+                                const result = await this.plugin.runSync('settings');
+                                this.plugin.reportSyncResult(result);
+                            } catch (e) {
+                                this.plugin.log('Sync failed:', e);
+                                this.plugin.notice('Failed to sync with Instapaper');
+                            } finally {
+                                button.setDisabled(false);
+                            }
+                        });
                 });
         });
 


### PR DESCRIPTION
This is a convenient place to provide a way for users to manually run a sync operation. (They otherwise need to run the "Sync" command or use their notes folder's context menu.)

<img width="424" height="134" alt="CleanShot 2026-04-19 at 09 18 59@2x" src="https://github.com/user-attachments/assets/e823c620-2ec1-4d49-94c7-9df9f1a701c8" />