### PR TITLE
Migrate to OAuth 2 and Instapaper API v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - Unreleased
+
+### Changed
+
+- Account connection now uses browser-based OAuth 2 authorization instead of entering credentials directly.
+- Added a "Sync now" button to the settings page.
+
 ## [1.2.1] - 2026-04-04
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,7 @@
 			"version": "1.2.1",
 			"license": "MIT",
 			"dependencies": {
-				"hmacsha1": "^1.0.0",
-				"mustache": "^4.2.0",
-				"oauth-1.0a": "^2.2.6"
+				"mustache": "^4.2.0"
 			},
 			"devDependencies": {
 				"@eslint/js": "^10.0.1",
@@ -1445,11 +1443,6 @@
 				"node": ">=10.13.0"
 			}
 		},
-		"node_modules/hmacsha1": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/hmacsha1/-/hmacsha1-1.0.0.tgz",
-			"integrity": "sha512-4FP6J0oI8jqb6gLLl9tSwVdosWJ/AKSGJ+HwYf6Ixe4MUcEkst4uWzpVQrNOCin0fzTRQbXV8ePheU8WiiDYBw=="
-		},
 		"node_modules/ignore": {
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -1600,11 +1593,6 @@
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
-		},
-		"node_modules/oauth-1.0a": {
-			"version": "2.2.6",
-			"resolved": "https://registry.npmjs.org/oauth-1.0a/-/oauth-1.0a-2.2.6.tgz",
-			"integrity": "sha512-6bkxv3N4Gu5lty4viIcIAnq5GbxECviMBeKR3WX/q87SPQ8E8aursPZUtsXDnxCs787af09WPRBLqYrf/lwoYQ=="
 		},
 		"node_modules/obsidian": {
 			"version": "1.11.0",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,6 @@
 		"typescript-eslint": "^8.58.0"
 	},
 	"dependencies": {
-		"hmacsha1": "^1.0.0",
-		"mustache": "^4.2.0",
-		"oauth-1.0a": "^2.2.6"
+		"mustache": "^4.2.0"
 	}
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,137 +1,155 @@
-import OAuth from "oauth-1.0a";
-import hmacsha1 from "hmacsha1";
 import { requestUrl } from "obsidian";
 
 export interface InstapaperClientOptions {
     baseURL: string;
+    oauthRedirectURI: string;
 }
 
 const DEFAULT_OPTIONS: InstapaperClientOptions = {
-    baseURL: 'https://www.instapaper.com/api'
+    baseURL: 'https://www.instapaper.com',
+    oauthRedirectURI: 'obsidian://instapaper-auth',
 }
 
-// Like OAuth.Token but distinct so it can be used as a stable Settings type.
 export type InstapaperAccessToken = {
     key: string;
-    secret: string;
+    secret?: string; // unused, retained for downgrade safety
 }
 
 export type InstapaperAccount = {
-    type: "user";
-    user_id: number;
+    id: number;
     username: string;
 }
 
 export type InstapaperBookmark = {
-    type: "bookmark";
-    author: string;
-    bookmark_id: number;
-    description: string;
-    hash: string;
-    private_source: string;
-    progress: number;
-    progress_timestamp: number;
-    pubtime: number;
-    starred: "0" | "1";
-    tags: InstapaperTag[];
+    id: number;
+    url: string | null;
+    title: string | null;
+    description: string | null;
+    image: string | null;
+    progress: {
+        percentage: number;
+        timestamp: number;
+    };
+    liked: boolean;
+    archived: boolean;
     time: number;
-    title: string;
-    url: string;
-    words: number;
+    tags: InstapaperTag[];
+    private_source: string | null;
+    author: string | null;
+    pubtime: number | null;
 }
 
 export type InstapaperTag = {
-    count: number;
-    hash: string;
     id: number;
     name: string;
     slug: string;
-    time: number;
+    count: number;
+    baton: string | null;
 }
 
 export type InstapaperHighlight = {
-    highlight_id: number;
-    article_id: string;
-    time: number;
+    id: number;
+    bookmark_id: number;
     text: string;
     note: string | null;
+    position: number;
+    time: number;
 }
 
 export class InstapaperAPI {
-    oauth: OAuth
+    private consumerKey: string;
+    private consumerSecret: string;
     options: InstapaperClientOptions;
 
-    constructor(consumerKey: string, consumerSecret: string, options?: InstapaperClientOptions) {
-        this.oauth = new OAuth({
-            consumer: {
-                key: consumerKey,
-                secret: consumerSecret,
-            },
-            signature_method: "HMAC-SHA1",
-            hash_function(base_string: string, key: string) {
-                return hmacsha1(key, base_string);
-            },
-            parameter_seperator: ", "
-        });
+    constructor(consumerKey: string, consumerSecret: string, options?: Partial<InstapaperClientOptions>) {
+        this.consumerKey = consumerKey;
+        this.consumerSecret = consumerSecret;
         this.options = Object.assign({}, DEFAULT_OPTIONS, options);
     }
 
-    private async fetch(request: OAuth.RequestOptions, token?: OAuth.Token) {
-        const authorization = this.oauth.authorize(request, token);
-
-        let url = request.url;
+    private async fetch(
+        url: string,
+        method: string,
+        token: InstapaperAccessToken,
+        data?: Record<string, unknown>,
+        options?: { json?: boolean },
+    ) {
+        let requestURL = url;
         let body: string | undefined;
         let contentType: string | undefined;
 
-        if (request.data) {
-            if (request.method == 'GET') {
-                url += '?' + new URLSearchParams(request.data).toString();
+        if (data) {
+            if (method === 'GET') {
+                const params = new URLSearchParams();
+                for (const [k, v] of Object.entries(data)) {
+                    if (v != null) params.set(k, String(v));
+                }
+                requestURL += '?' + params.toString();
+            } else if (options?.json) {
+                body = JSON.stringify(data);
+                contentType = "application/json";
             } else {
-                body = new URLSearchParams(request.data).toString();
+                body = new URLSearchParams(data as Record<string, string>).toString();
                 contentType = "application/x-www-form-urlencoded";
             }
         }
 
-        return await requestUrl({
-            url: url,
-            method: request.method,
-            contentType: contentType,
-            body: body,
-            headers: { ...this.oauth.toHeader(authorization) },
-            throw: true,
-        });
+        try {
+            return await requestUrl({
+                url: requestURL,
+                method: method,
+                contentType: contentType,
+                body: body,
+                headers: {
+                    'Authorization': `Bearer ${token.key}`,
+                },
+                throw: true,
+            });
+        } catch (e) {
+            throw new Error(`${method} ${requestURL}: ${e}`, { cause: e });
+        }
     }
 
-    async getAccessToken(username: string, password: string): Promise<InstapaperAccessToken> {
-        const response = await this.fetch(
-            {
-                url: `${this.options.baseURL}/1.1/oauth/access_token`,
-                method: 'POST',
-                data: {
-                    x_auth_username: username,
-                    x_auth_password: password,
-                    x_auth_mode: "client_auth",
-                },
-            }
-        )
+    getAuthorizeURL(): string {
+        const params = new URLSearchParams({
+            client_id: this.consumerKey,
+            redirect_uri: this.options.oauthRedirectURI,
+            response_type: 'code',
+        });
+        return `${this.options.baseURL}/oauth2/authorize?${params.toString()}`;
+    }
 
-        const params = new URLSearchParams(response.text);
-        const key = params.get("oauth_token") || "";
-        const secret = params.get("oauth_token_secret") || "";
-        return { key, secret }
+    async exchangeCode(
+        code: string,
+    ): Promise<{ token: InstapaperAccessToken; account: InstapaperAccount }> {
+        const response = await requestUrl({
+            url: `${this.options.baseURL}/oauth2/token`,
+            method: 'POST',
+            contentType: 'application/x-www-form-urlencoded',
+            body: new URLSearchParams({
+                client_id: this.consumerKey,
+                redirect_uri: this.options.oauthRedirectURI,
+                client_secret: this.consumerSecret,
+                code: code,
+            }).toString(),
+            throw: true,
+        });
+
+        const data = await response.json;
+        return {
+            token: { key: data.access_token },
+            account: data.user as InstapaperAccount,
+        };
     }
 
     async verifyCredentials(token: InstapaperAccessToken): Promise<InstapaperAccount> {
         const response = await this.fetch(
-            {
-                url: `${this.options.baseURL}/1.1/account/verify_credentials`,
-                method: 'POST',
-            },
+            `${this.options.baseURL}/api/2/me`,
+            'GET',
             token,
-        )
+        );
 
-        const data = (await response.json) as [InstapaperAccount]
-        return data[0];
+        return (await response.json) as InstapaperAccount;
     }
 
     async addBookmark(
@@ -144,16 +162,14 @@ export class InstapaperAPI {
         },
     ): Promise<InstapaperBookmark> {
         const response = await this.fetch(
-            {
-                url: `${this.options.baseURL}/1.1/bookmarks/add`,
-                method: 'POST',
-                data: data,
-            },
+            `${this.options.baseURL}/api/2/bookmarks`,
+            'POST',
             token,
+            data,
+            { json: true },
         );
 
-        const bookmarks = await response.json as [InstapaperBookmark]
-        return bookmarks[0];
+        return (await response.json) as InstapaperBookmark;
     }
 
     async getHighlights(
@@ -163,29 +179,26 @@ export class InstapaperAPI {
             offset?: number,
             limit?: number,
             sort?: 'asc' | 'desc',
-
         },
     ): Promise<{
-        highlights: [InstapaperHighlight],
-        bookmarks: Record<string, InstapaperBookmark>,
+        highlights: InstapaperHighlight[],
+        bookmarks: Record<number, InstapaperBookmark>,
     }> {
         const response = await this.fetch(
-            {
-                url: `${this.options.baseURL}/highlights`,
-                method: 'GET',
-                data: data,
-            },
+            `${this.options.baseURL}/api/2/private/highlights`,
+            'GET',
             token,
-        )
+            data,
+        );
 
         const { highlights, bookmarks }: {
-            highlights: [InstapaperHighlight],
-            bookmarks: [InstapaperBookmark],
+            highlights: InstapaperHighlight[],
+            bookmarks: InstapaperBookmark[],
         } = await response.json;
 
         return {
             highlights,
-            bookmarks: Object.fromEntries(bookmarks.map(b => [b.bookmark_id, b]))
+            bookmarks: Object.fromEntries(bookmarks.map(b => [b.id, b]))
         }
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ type SyncResult = {
 export default class InstapaperPlugin extends Plugin {
 	settings!: InstapaperPluginSettings;
 	api!: InstapaperAPI;
+	settingTab?: InstapaperSettingTab;
 	syncInterval?: number;
 	syncInProgress = false;
 
@@ -21,7 +22,28 @@ export default class InstapaperPlugin extends Plugin {
 		);
 
 		await this.loadSettings();
-		this.addSettingTab(new InstapaperSettingTab(this.app, this));
+
+		this.settingTab = new InstapaperSettingTab(this.app, this);
+		this.addSettingTab(this.settingTab);
+
+		this.registerObsidianProtocolHandler('instapaper-auth', async (params) => {
+			if (this.settingTab) {
+				this.settingTab.authorizing = false;
+			}
+			if (params.error) {
+				this.notice('Failed to connect Instapaper account');
+			} else if (params.code) {
+				try {
+					const account = await this.connectAccount(params.code);
+					this.notice(`Connected Instapaper account: ${account.username}`);
+				} catch (e) {
+					this.log('Failed to connect account:', e);
+					await this.disconnectAccount();
+					this.notice('Failed to connect Instapaper account');
+				}
+			}
+			this.settingTab?.display();
+		});
 
 		this.registerEvent(
 			this.app.workspace.on('url-menu', (menu, url) => {
@@ -35,7 +57,7 @@ export default class InstapaperPlugin extends Plugin {
 						.onClick(async () => {
 							try {
 								const bookmark = await this.api.addBookmark(token, { url })
-								this.notice(`Saved "${bookmark.title}" to Instapaper`);
+								this.notice(`Saved "${bookmark.title ?? url}" to Instapaper`);
 							} catch (e) {
 								this.notice(`Unable to save to Instapaper`);
 								this.log('failed to add bookmark:', e);
@@ -176,9 +198,8 @@ export default class InstapaperPlugin extends Plugin {
 
 	// ACCOUNT
 
-	async connectAccount(username: string, password: string): Promise<InstapaperAccount> {
-		const token = await this.api.getAccessToken(username, password);
-		const account = await this.api.verifyCredentials(token);
+	async connectAccount(code: string): Promise<InstapaperAccount> {
+		const { token, account } = await this.api.exchangeCode(code);
 		await this.saveSettings({
 			token: token,
 			account: account,

--- a/src/notes.ts
+++ b/src/notes.ts
@@ -80,7 +80,7 @@ export async function syncNotes(
 
     while (true) {
         let highlights: InstapaperHighlight[];
-        let bookmarks: Record<string, InstapaperBookmark>;
+        let bookmarks: Record<number, InstapaperBookmark>;
 
         try {
             ({ highlights, bookmarks } = await plugin.api.getHighlights(token, {
@@ -100,9 +100,9 @@ export async function syncNotes(
         if (highlights.length === 0) break;
 
         for (const highlight of highlights) {
-            cursor = highlight.highlight_id;
+            cursor = highlight.id;
 
-            const article = bookmarks[highlight.article_id];
+            const article = bookmarks[highlight.bookmark_id];
             if (!article) continue;
 
             // Resolve a TFile for this article. This will be an existing file,
@@ -164,9 +164,9 @@ async function fileForArticle(
     create: boolean = true
 ): Promise<TFile | null> {
     // Use a sanitized version of the article's title for our filename.
-    let name = article.title.replace(/[\\/:<>?|*"]/gm, '').substring(0, 250).trim();
+    let name = (article.title ?? '').replace(/[\\/:<>?|*"]/gm, '').substring(0, 250).trim();
     if (!name) {
-        name = `Untitled-${article.bookmark_id}`;
+        name = `Untitled-${article.id}`;
     }
 
     const path = normalizePath(`${folder}/${name}.md`);
@@ -176,12 +176,12 @@ async function fileForArticle(
 }
 
 function linkForHighlight(highlight: InstapaperHighlight): string {
-    return `https://www.instapaper.com/read/${highlight.article_id}/${highlight.highlight_id}`
+    return `https://www.instapaper.com/read/${highlight.bookmark_id}/${highlight.id}`
 }
 
 // https://help.obsidian.md/links#Link+to+a+block+in+a+note
 function blockIdentifierForHighlight(highlight: InstapaperHighlight): string {
-    return `^h${highlight.highlight_id}`;
+    return `^h${highlight.id}`;
 }
 
 function hasHighlightMarker(content: string, highlight: InstapaperHighlight): boolean {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,4 +1,4 @@
-import { App, ButtonComponent, Modal, PluginSettingTab, Setting, SettingGroup, TextAreaComponent, TextComponent, TFolder, normalizePath } from "obsidian";
+import { App, ButtonComponent, PluginSettingTab, Setting, SettingGroup, TextAreaComponent, TextComponent, TFolder, normalizePath } from "obsidian";
 import InstapaperPlugin from "./main";
 import type { InstapaperAccessToken, InstapaperAccount } from "./api";
 
@@ -66,6 +66,7 @@ export const DEFAULT_SETTINGS = {
 
 export class InstapaperSettingTab extends PluginSettingTab {
     plugin: InstapaperPlugin;
+    authorizing = false;
 
     constructor(app: App, plugin: InstapaperPlugin) {
         super(app, plugin);
@@ -102,6 +103,16 @@ export class InstapaperSettingTab extends PluginSettingTab {
                         this.display();
                     })
                 });
+        } else if (this.authorizing) {
+            setting
+                .setDesc('Waiting for authorization in your browser…')
+                .addButton((button) => {
+                    button.setButtonText('Cancel');
+                    button.onClick(() => {
+                        this.authorizing = false;
+                        this.display();
+                    });
+                });
         } else {
             setting
                 .setDesc('Connect your Instapaper account')
@@ -109,18 +120,10 @@ export class InstapaperSettingTab extends PluginSettingTab {
                     button.setButtonText('Connect');
                     button.setTooltip('Connect your Instapaper account')
                     button.setCta();
-                    button.onClick(async () => {
-                        new ConnectAccountModal(this.app, async (username: string, password: string) => {
-                            try {
-                                const account = await this.plugin.connectAccount(username, password);
-                                this.plugin.notice(`Connected Instapaper account: ${account.username}`);
-                            } catch (e) {
-                                console.log('Failed to connect account:', e);
-                                await this.plugin.disconnectAccount();
-                                this.plugin.notice('Failed to connect Instapaper account');
-                            }
-                            this.display();
-                        }).open();
+                    button.onClick(() => {
+                        this.authorizing = true;
+                        this.display();
+                        window.open(this.plugin.api.getAuthorizeURL());
                     })
                 });
         }
@@ -420,90 +423,5 @@ export class InstapaperSettingTab extends PluginSettingTab {
                     });
             });
         });
-    }
-}
-
-class ConnectAccountModal extends Modal {
-    username!: string
-    password!: string
-    onConnect: (username: string, password: string) => Promise<void>;
-
-    constructor(app: App, onConnect: (username: string, password: string) => Promise<void>) {
-        super(app);
-        this.onConnect = onConnect;
-    }
-
-    onOpen() {
-        const group = new SettingGroup(this.contentEl)
-            .setHeading('Instapaper account')
-            .addClass('instapaper-connect-account');
-
-        let usernameEl: HTMLInputElement;
-        let passwordEl: HTMLInputElement;
-        let connectButton: ButtonComponent;
-
-        const updateConnectButton = () => {
-            const valid = usernameEl.checkValidity() && passwordEl.checkValidity();
-            connectButton.setDisabled(!valid);
-        };
-
-        group.addSetting((setting) => {
-            setting
-                .setName("Email")
-                .addText((text) => {
-                    text.inputEl.addEventListener('blur', () => {
-                        text.inputEl.required = true;
-                    });
-                    text.onChange((value) => {
-                        this.username = value;
-                        updateConnectButton();
-                    });
-                    usernameEl = text.inputEl;
-                });
-        });
-
-        group.addSetting((setting) => {
-            setting
-                .setName("Password")
-                .addText((text) => {
-                    text.inputEl.type = "password";
-                    text.onChange((value) => {
-                        this.password = value;
-                        updateConnectButton();
-                    });
-                    passwordEl = text.inputEl;
-                });
-        });
-
-        group.addSetting((setting) => {
-            const descEl = setting.descEl;
-            descEl.createSpan({ text: "If you don't have an account, you can " });
-            descEl.createEl('a', {
-                text: 'create one',
-                href: 'https://www.instapaper.com/user/register',
-            });
-            descEl.createSpan({ text: ' on the Instapaper website.' });
-        });
-
-        const footer = this.modalEl.createDiv({ cls: 'modal-button-container' });
-
-        new Setting(footer)
-            .addButton((button) => {
-                button.setCta();
-                button.setButtonText("Connect");
-                button.setDisabled(true);
-                button.onClick(async () => {
-                    button.setButtonText("Connecting ...");
-                    button.setDisabled(true);
-                    await this.onConnect(this.username, this.password);
-                    this.close();
-                });
-                connectButton = button;
-            });
-    }
-
-    onClose() {
-        const { contentEl } = this;
-        contentEl.empty();
     }
 }

--- a/src/types/hmacsha1.d.ts
+++ b/src/types/hmacsha1.d.ts
@@ -1,1 +1,0 @@
-declare module 'hmacsha1';


### PR DESCRIPTION
This replaces the OAuth 1.0a xAuth flow (username+password) with an OAuth 2 authorization code flow that uses the system browser. Existing access tokens continue to work as Bearer tokens.