### PR TITLE
Improve notes folder renaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Account connection now uses browser-based OAuth 2 authorization instead of entering credentials directly.
 - Added a "Sync now" button to the settings page.
+- Improved notes folder renaming behavior in settings, and the setting now stays in sync when the folder is renamed elsewhere.
 
 ## [1.2.1] - 2026-04-04
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -68,6 +68,14 @@ export default class InstapaperPlugin extends Plugin {
 		);
 
 		this.registerEvent(
+			this.app.vault.on('rename', async (file, oldPath) => {
+				if (file instanceof TFolder && oldPath === this.settings.notesFolder) {
+					await this.saveSettings({ notesFolder: file.path });
+				}
+			})
+		);
+
+		this.registerEvent(
 			this.app.workspace.on('file-menu', (menu, file) => {
 				if (!(file instanceof TFolder && file.path == this.settings.notesFolder)) {
 					return;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -188,17 +188,32 @@ export class InstapaperSettingTab extends PluginSettingTab {
                 .setName('Notes folder')
                 .setDesc('The folder in which your notes and highlights will be synced.')
                 .addText((text) => {
-                    text.setValue(this.plugin.settings.notesFolder)
-                    text.onChange(async (value) => {
-                        const previousPath = this.plugin.settings.notesFolder;
-                        const newPath = normalizePath(value);
-                        await this.plugin.saveSettings({ notesFolder: newPath });
+                    text.setValue(this.plugin.settings.notesFolder);
 
-                        const previousFile = this.app.vault.getAbstractFileByPath(previousPath);
-                        if (previousFile instanceof TFolder) {
-                            await previousFile.vault.rename(previousFile, newPath);
+                    const commit = async () => {
+                        const previousPath = this.plugin.settings.notesFolder;
+                        const newPath = normalizePath(text.getValue());
+                        if (newPath === previousPath) return;
+
+                        try {
+                            const previousFile = this.app.vault.getAbstractFileByPath(previousPath);
+                            if (previousFile instanceof TFolder) {
+                                // The vault rename event will save the new path.
+                                await this.app.fileManager.renameFile(previousFile, newPath);
+                            } else {
+                                await this.plugin.saveSettings({ notesFolder: newPath });
+                            }
+                        } catch (e) {
+                            this.plugin.log('Failed to rename notes folder:', e);
+                            this.plugin.notice('Failed to rename notes folder');
+                            text.setValue(this.plugin.settings.notesFolder);
                         }
-                    })
+                    };
+
+                    text.inputEl.addEventListener('change', commit);
+                    text.inputEl.addEventListener('keydown', (e) => {
+                        if (e.key === 'Enter') text.inputEl.blur();
+                    });
                 });
         });
 


### PR DESCRIPTION
This improves the settings screen behavior (which previously renamed the folder as each input character was typed) and now also keeps the setting in sync when the folder is renamed elsewhere.