### PR TITLE
Fix OAuth redirect when Web Viewer is active

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,4 +1,4 @@
-import { App, ButtonComponent, PluginSettingTab, Setting, SettingGroup, TextAreaComponent, TextComponent, TFolder, normalizePath } from "obsidian";
+import { App, ButtonComponent, Platform, PluginSettingTab, Setting, SettingGroup, TextAreaComponent, TextComponent, TFolder, normalizePath } from "obsidian";
 import InstapaperPlugin from "./main";
 import type { InstapaperAccessToken, InstapaperAccount } from "./api";
 
@@ -123,7 +123,15 @@ export class InstapaperSettingTab extends PluginSettingTab {
                     button.onClick(() => {
                         this.authorizing = true;
                         this.display();
-                        window.open(this.plugin.api.getAuthorizeURL());
+
+                        // On Desktop, always bypass Obsidian's Web Viewer plugin
+                        // interception, which can't handle obsidian:// direct URLs.
+                        const url = this.plugin.api.getAuthorizeURL();
+                        if (Platform.isDesktopApp) {
+                            window.require?.('electron').shell.openExternal(url).catch(() => window.open(url));
+                        } else {
+                            window.open(url);
+                        }
                     })
                 });
         }

--- a/src/types/obsidian.d.ts
+++ b/src/types/obsidian.d.ts
@@ -3,3 +3,14 @@
 // Fix for missing Frontmatter type in obsidian.d.ts
 // This is a known issue with the Obsidian type definitions
 type Frontmatter = Record<string, unknown>;
+
+// Electron's `require` is exposed on `window` in the Obsidian desktop app.
+// Only the surface we actually use is typed here; guard calls with
+// `Platform.isDesktopApp` since `require` is undefined on mobile.
+interface Window {
+    require?: (module: 'electron') => {
+        shell: {
+            openExternal: (url: string) => Promise<void>;
+        };
+    };
+}


### PR DESCRIPTION
Obsidian's core Web Viewer plugin intercepts window.open() URLs, but it unfortunately can't handle links that use the obsidian:// scheme:

- https://forum.obsidian.md/t/obsidian-obsidian-uri-links-not-working-within-official-web-viewer-plugin/103879
- https://forum.obsidian.md/t/obsidian-web-viewer-add-support-for-obsidian-uri/100974

We use obsidian:// URLs as part of our OAuth redirect, so we work around this desktop limitation by invoking Electron's `shell.openExternal` to launch the system's default browser directly.