### PR TITLE
Track individual OAuth states

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -27,12 +27,16 @@ export default class InstapaperPlugin extends Plugin {
 		this.addSettingTab(this.settingTab);
 
 		this.registerObsidianProtocolHandler('instapaper-auth', async (params) => {
-			if (this.settingTab) {
-				this.settingTab.authorizing = false;
-			}
 			if (params.error) {
+				if (this.settingTab) {
+					this.settingTab.authState = 'idle';
+				}
 				this.notice('Failed to connect Instapaper account');
 			} else if (params.code) {
+				if (this.settingTab) {
+					this.settingTab.authState = 'exchange';
+					this.settingTab.display();
+				}
 				try {
 					const account = await this.connectAccount(params.code);
 					this.notice(`Connected Instapaper account: ${account.username}`);
@@ -42,7 +46,10 @@ export default class InstapaperPlugin extends Plugin {
 					this.notice('Failed to connect Instapaper account');
 				}
 			}
-			this.settingTab?.display();
+			if (this.settingTab) {
+				this.settingTab.authState = 'idle';
+				this.settingTab.display();
+			}
 		});
 
 		this.registerEvent(

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -66,7 +66,7 @@ export const DEFAULT_SETTINGS = {
 
 export class InstapaperSettingTab extends PluginSettingTab {
     plugin: InstapaperPlugin;
-    authorizing = false;
+    authState: 'idle' | 'browser' | 'exchange' = 'idle';
 
     constructor(app: App, plugin: InstapaperPlugin) {
         super(app, plugin);
@@ -103,13 +103,15 @@ export class InstapaperSettingTab extends PluginSettingTab {
                         this.display();
                     })
                 });
-        } else if (this.authorizing) {
+        } else if (this.authState === 'exchange') {
+            setting.setDesc('Connecting your account…');
+        } else if (this.authState === 'browser') {
             setting
                 .setDesc('Waiting for authorization in your browser…')
                 .addButton((button) => {
                     button.setButtonText('Cancel');
                     button.onClick(() => {
-                        this.authorizing = false;
+                        this.authState = 'idle';
                         this.display();
                     });
                 });
@@ -121,7 +123,7 @@ export class InstapaperSettingTab extends PluginSettingTab {
                     button.setTooltip('Connect your Instapaper account')
                     button.setCta();
                     button.onClick(() => {
-                        this.authorizing = true;
+                        this.authState = 'browser';
                         this.display();
 
                         // On Desktop, always bypass Obsidian's Web Viewer plugin


### PR DESCRIPTION
1. idle → "Connect your Instapaper account" with Connect button
2. browser → "Waiting for authorization in your browser…" with Cancel button
3. exchange → "Connecting your account…" (the token exchange is in-flight)

This better represents the OAuth flow and provides more user-visible feedback if the token exchange takes a little bit of time to complete.