### PR TITLE
Improve typing and enable typed eslint rules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,7 +5,15 @@ import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
     eslint.configs.recommended,
-    tseslint.configs.recommended,
+    tseslint.configs.recommendedTypeChecked,
     {
-        ignores: ["main.js"]
-    });
+        languageOptions: {
+            parserOptions: {
+                projectService: true,
+            },
+        },
+    },
+    {
+        ignores: ['main.js'],
+    },
+);

--- a/src/api.ts
+++ b/src/api.ts
@@ -56,6 +56,14 @@ export type InstapaperHighlight = {
     time: number;
 }
 
+function encodeFormData(data: Record<string, string | number | boolean | null | undefined>): string {
+    const params = new URLSearchParams();
+    for (const [k, v] of Object.entries(data)) {
+        if (v != null) params.set(k, String(v));
+    }
+    return params.toString();
+}
+
 export class InstapaperAPI {
     private consumerKey: string;
     private consumerSecret: string;
@@ -67,35 +75,31 @@ export class InstapaperAPI {
         this.options = Object.assign({}, DEFAULT_OPTIONS, options);
     }
 
-    private async fetch(
+    private async fetch<T>(
         url: string,
         method: string,
         token: InstapaperAccessToken,
-        data?: Record<string, unknown>,
+        data?: Record<string, string | number | boolean | null | undefined>,
         options?: { json?: boolean },
-    ) {
+    ): Promise<T> {
         let requestURL = url;
         let body: string | undefined;
         let contentType: string | undefined;
 
         if (data) {
             if (method === 'GET') {
-                const params = new URLSearchParams();
-                for (const [k, v] of Object.entries(data)) {
-                    if (v != null) params.set(k, String(v));
-                }
-                requestURL += '?' + params.toString();
+                requestURL += '?' + encodeFormData(data);
             } else if (options?.json) {
                 body = JSON.stringify(data);
                 contentType = "application/json";
             } else {
-                body = new URLSearchParams(data as Record<string, string>).toString();
+                body = encodeFormData(data);
                 contentType = "application/x-www-form-urlencoded";
             }
         }
 
         try {
-            return await requestUrl({
+            const response = await requestUrl({
                 url: requestURL,
                 method: method,
                 contentType: contentType,
@@ -105,8 +109,10 @@ export class InstapaperAPI {
                 },
                 throw: true,
             });
+            return (await response.json) as T;
         } catch (e) {
-            throw new Error(`${method} ${requestURL}: ${e}`, { cause: e });
+            const message = e instanceof Error ? e.message : String(e);
+            throw new Error(`${method} ${requestURL}: ${message}`, { cause: e });
         }
     }
 
@@ -135,21 +141,22 @@ export class InstapaperAPI {
             throw: true,
         });
 
-        const data = await response.json;
+        const data = (await response.json) as {
+            access_token: string;
+            user: InstapaperAccount;
+        };
         return {
             token: { key: data.access_token },
-            account: data.user as InstapaperAccount,
+            account: data.user,
         };
     }
 
     async verifyCredentials(token: InstapaperAccessToken): Promise<InstapaperAccount> {
-        const response = await this.fetch(
+        return await this.fetch<InstapaperAccount>(
             `${this.options.baseURL}/api/2/me`,
             'GET',
             token,
         );
-
-        return (await response.json) as InstapaperAccount;
     }
 
     async addBookmark(
@@ -161,15 +168,13 @@ export class InstapaperAPI {
             folder_id?: number,
         },
     ): Promise<InstapaperBookmark> {
-        const response = await this.fetch(
+        return await this.fetch<InstapaperBookmark>(
             `${this.options.baseURL}/api/2/bookmarks`,
             'POST',
             token,
             data,
             { json: true },
         );
-
-        return (await response.json) as InstapaperBookmark;
     }
 
     async getHighlights(
@@ -184,17 +189,15 @@ export class InstapaperAPI {
         highlights: InstapaperHighlight[],
         bookmarks: Record<number, InstapaperBookmark>,
     }> {
-        const response = await this.fetch(
+        const { highlights, bookmarks } = await this.fetch<{
+            highlights: InstapaperHighlight[],
+            bookmarks: InstapaperBookmark[],
+        }>(
             `${this.options.baseURL}/api/2/private/highlights`,
             'GET',
             token,
             data,
         );
-
-        const { highlights, bookmarks }: {
-            highlights: InstapaperHighlight[],
-            bookmarks: InstapaperBookmark[],
-        } = await response.json;
 
         return {
             highlights,

--- a/src/frontmatter.ts
+++ b/src/frontmatter.ts
@@ -1,6 +1,6 @@
 import { TFile, FileManager, moment } from "obsidian";
 import type { InstapaperBookmark, InstapaperTag } from "./api";
-import type { FrontmatterSettings } from "./settings";
+import type { FrontmatterField, FrontmatterSettings } from "./settings";
 import { DEFAULT_SETTINGS } from "./settings";
 
 /**
@@ -30,7 +30,7 @@ export async function applyArticleFrontmatter(
 ): Promise<void> {
     // Property order is preserved for existing files while new files
     // will have properties added in the order below.
-    await fileManager.processFrontMatter(file, (frontmatter) => {
+    await fileManager.processFrontMatter(file, (frontmatter: Record<string, unknown>) => {
         if (settings.title.enabled && settings.title.propertyName) {
             if (article.title) {
                 frontmatter[settings.title.propertyName] = article.title;
@@ -84,8 +84,8 @@ export async function applyArticleFrontmatter(
         }
 
         if (options?.removeDisabled) {
-            const settingsFields = Object.values(settings);
-            const defaultFields = Object.values(DEFAULT_SETTINGS.frontmatter);
+            const settingsFields = Object.values(settings) as FrontmatterField[];
+            const defaultFields = Object.values(DEFAULT_SETTINGS.frontmatter) as FrontmatterField[];
 
             // Enabled properties (in settings)
             const enabledNames = new Set(

--- a/src/main.ts
+++ b/src/main.ts
@@ -158,27 +158,37 @@ export default class InstapaperPlugin extends Plugin {
 	// SETTINGS
 
 	async loadSettings() {
-		const data = await this.loadData();
+		// Properties from older versions of the plugin that may still be
+		// present in saved user data and require migration.
+		type LegacySettings = {
+			notesFrequency?: number;
+			notesSyncOnStart?: boolean;
+		};
 
-		// Migrate pre-0.7.0 settings
+		const data = await this.loadData() as
+			(Partial<InstapaperPluginSettings> & LegacySettings) | null;
+
 		let needsSave = false;
-		if (data && Object.hasOwnProperty.call(data, 'notesFrequency')) {
-			data['syncFrequency'] = data['notesFrequency'];
-			delete data['notesFrequency'];
-			needsSave = true;
-		}
-		if (data && Object.hasOwnProperty.call(data, 'notesSyncOnStart')) {
-			data['syncOnStart'] = data['notesSyncOnStart'];
-			delete data['notesSyncOnStart'];
-			needsSave = true;
-		}
+		if (data) {
+			// Migrate pre-0.7.0 settings
+			if (Object.hasOwnProperty.call(data, 'notesFrequency')) {
+				data.syncFrequency = data.notesFrequency;
+				delete data.notesFrequency;
+				needsSave = true;
+			}
+			if (Object.hasOwnProperty.call(data, 'notesSyncOnStart')) {
+				data.syncOnStart = data.notesSyncOnStart;
+				delete data.notesSyncOnStart;
+				needsSave = true;
+			}
 
-		// Seed highlightTemplate for users upgrading from before template
-		// customization was introduced. Existing notes were written with
-		// the legacy format.
-		if (data && !Object.hasOwnProperty.call(data, 'appliedHighlightTemplate')) {
-			data['highlightTemplate'] = LEGACY_HIGHLIGHT_TEMPLATE;
-			needsSave = true;
+			// Seed highlightTemplate for users upgrading from before template
+			// customization was introduced. Existing notes were written with
+			// the legacy format.
+			if (!Object.hasOwnProperty.call(data, 'appliedHighlightTemplate')) {
+				data.highlightTemplate = LEGACY_HIGHLIGHT_TEMPLATE;
+				needsSave = true;
+			}
 		}
 
 		// Merge our defaults with the user's saved data. This needs to be a
@@ -195,7 +205,7 @@ export default class InstapaperPlugin extends Plugin {
 			await this.saveSettings();
 		}
 
-		await this.updateSyncInterval();
+		this.updateSyncInterval();
 	}
 
 	async saveSettings(updates?: Partial<InstapaperPluginSettings>) {
@@ -220,7 +230,7 @@ export default class InstapaperPlugin extends Plugin {
 			account: account,
 		});
 
-		await this.updateSyncInterval();
+		this.updateSyncInterval();
 		if (this.settings.syncOnStart) {
 			await this.runSync('on connect');
 		}
@@ -282,7 +292,7 @@ export default class InstapaperPlugin extends Plugin {
 		this.syncInterval = undefined;
 	}
 
-	async updateSyncInterval() {
+	updateSyncInterval() {
 		this.log('setting sync frequency to',
 			this.settings.syncFrequency,
 			this.settings.syncFrequency ? 'minutes' : '(manual)'
@@ -294,7 +304,7 @@ export default class InstapaperPlugin extends Plugin {
 		if (!timeout) return; // manual
 
 		this.syncInterval = window.setInterval(() => {
-			this.runSync('scheduled')
+			void this.runSync('scheduled')
 		}, timeout);
 		this.registerInterval(this.syncInterval);
 	}

--- a/src/notes.ts
+++ b/src/notes.ts
@@ -5,7 +5,7 @@ import type { InstapaperAccessToken, InstapaperBookmark, InstapaperHighlight } f
 import { applyArticleFrontmatter } from "./frontmatter";
 
 // Disable HTML escaping. We render to Markdown.
-Mustache.escape = (text) => text;
+Mustache.escape = (text: string) => text;
 
 export interface SyncNotesOptions {
     /**

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -155,7 +155,7 @@ export class InstapaperSettingTab extends PluginSettingTab {
                     dropdown.setValue(Number(this.plugin.settings.syncFrequency).toString());
                     dropdown.onChange(async (value) => {
                         await this.plugin.saveSettings({ syncFrequency: parseInt(value) });
-                        await this.plugin.updateSyncInterval();
+                        this.plugin.updateSyncInterval();
                     });
                 })
                 .addButton((button) => {
@@ -220,7 +220,7 @@ export class InstapaperSettingTab extends PluginSettingTab {
                         }
                     };
 
-                    text.inputEl.addEventListener('change', commit);
+                    text.inputEl.addEventListener('change', () => { void commit(); });
                     text.inputEl.addEventListener('keydown', (e) => {
                         if (e.key === 'Enter') text.inputEl.blur();
                     });
@@ -252,12 +252,15 @@ export class InstapaperSettingTab extends PluginSettingTab {
                     text: 'Reset to default',
                     href: '#'
                 });
-                resetLink.addEventListener('click', async (e) => {
+                resetLink.addEventListener('click', (e) => {
                     e.preventDefault();
                     textareaComponent.setValue(DEFAULT_HIGHLIGHT_TEMPLATE);
                     updateButton?.setDisabled(templateIsApplied(DEFAULT_HIGHLIGHT_TEMPLATE));
-                    await this.plugin.saveSettings({
+                    this.plugin.saveSettings({
                         highlightTemplate: DEFAULT_HIGHLIGHT_TEMPLATE
+                    }).catch(e => {
+                        this.plugin.log('Failed to save template:', e);
+                        this.plugin.notice('Failed to save template');
                     });
                 });
                 el.appendText(' · ');


### PR DESCRIPTION
Enable typescript-eslint's recommendedTypeChecked preset to surface unsafe `any` usage and unawaited promises, and then resolve these:

- Type the OAuth and highlights API responses, returning parsed JSON as a caller-supplied type.
- More strictly type the Obsidian frontmatter values.
- Add a local LegacySettings type for the pre-0.7.0 migration in loadSettings and consolidate the redundant `if (data &&)` checks.
- Drop a unneeded `async` from updateSyncInterval.
- Annotate the Mustache.escape callback parameter.
- Wrap async event handlers so they return void.