### PR TITLE
Adopt eslint-plugin-no-unsanitized and eslint-plugin-security

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,16 +1,25 @@
 // @ts-check
 
 import eslint from '@eslint/js';
+import noUnsanitized from 'eslint-plugin-no-unsanitized';
+import security from 'eslint-plugin-security';
 import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
     eslint.configs.recommended,
     tseslint.configs.recommendedTypeChecked,
+    noUnsanitized.configs.recommended,
+    security.configs.recommended,
     {
         languageOptions: {
             parserOptions: {
                 projectService: true,
             },
+        },
+        rules: {
+            // Noisy in TypeScript: fires on every computed property access
+            // even when the key is constrained by `keyof T`.
+            'security/detect-object-injection': 'off',
         },
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,8 @@
 				"dotenv": "^17.4.2",
 				"esbuild": "0.28.0",
 				"eslint": "^10.0.2",
+				"eslint-plugin-no-unsanitized": "^4.1.5",
+				"eslint-plugin-security": "^4.0.0",
 				"obsidian": "1.11.0",
 				"typescript": "^6.0.3",
 				"typescript-eslint": "^8.59.0"
@@ -1222,6 +1224,32 @@
 				}
 			}
 		},
+		"node_modules/eslint-plugin-no-unsanitized": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-no-unsanitized/-/eslint-plugin-no-unsanitized-4.1.5.tgz",
+			"integrity": "sha512-MSB4hXPVFQrI8weqzs6gzl7reP2k/qSjtCoL2vUMSDejIIq9YL1ZKvq5/ORBXab/PvfBBrWO2jWviYpL+4Ghfg==",
+			"dev": true,
+			"license": "MPL-2.0",
+			"peerDependencies": {
+				"eslint": "^9 || ^10"
+			}
+		},
+		"node_modules/eslint-plugin-security": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-4.0.0.tgz",
+			"integrity": "sha512-tfuQT8K/Li1ZxhFzyD8wPIKtlzZxqBcPr9q0jFMQ77wWAbKBVEhaMPVQRTMTvCMUDhwBe5vPVqQPwAGk/ASfxQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"safe-regex": "^2.1.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
 		"node_modules/eslint-scope": {
 			"version": "9.1.1",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.1.tgz",
@@ -1704,6 +1732,26 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/regexp-tree": {
+			"version": "0.1.27",
+			"resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+			"integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"regexp-tree": "bin/regexp-tree"
+			}
+		},
+		"node_modules/safe-regex": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+			"integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"regexp-tree": "~0.1.1"
 			}
 		},
 		"node_modules/semver": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
 		"dotenv": "^17.4.2",
 		"esbuild": "0.28.0",
 		"eslint": "^10.0.2",
+		"eslint-plugin-no-unsanitized": "^4.1.5",
+		"eslint-plugin-security": "^4.0.0",
 		"obsidian": "1.11.0",
 		"typescript": "^6.0.3",
 		"typescript-eslint": "^8.59.0"


### PR DESCRIPTION
- eslint-plugin-no-unsanitized: catches unsafe DOM insertions (innerHTML, outerHTML, insertAdjacentHTML, etc.).
- eslint-plugin-security: catches eval, unsafe child_process, regex DoS, and similar patterns. The detect-object-injection rule is disabled because it's noisy in TypeScript code with keyof-constrained property access.

No findings in the current codebase.