### PR TITLE
Harden supply chain posture

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,3 +28,11 @@ updates:
       - dependency-name: "typescript-eslint"
         update-types:
           - version-update:semver-patch
+      - dependency-name: "esbuild"
+        update-types:
+          - version-update:semver-minor
+          - version-update:semver-patch
+      - dependency-name: "typescript"
+        update-types:
+          - version-update:semver-minor
+          - version-update:semver-patch

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,14 +12,16 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         node-version: [22.x]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Set up Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
       - name: Install packages
         run: npm ci
+      - name: Verify package signatures
+        run: npm audit signatures
       - name: Lint
         run: npm run lint
       - name: Build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,28 +13,30 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22.x
           cache: 'npm'
       - name: Install packages
         run: npm ci
+      - name: Verify package signatures
+        run: npm audit signatures
       - name: Build
         run: npm run build
         env:
           INSTAPAPER_CONSUMER_KEY: ${{ secrets.INSTAPAPER_CONSUMER_KEY }}
           INSTAPAPER_CONSUMER_SECRET: ${{ secrets.INSTAPAPER_CONSUMER_SECRET }}
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         with:
           subject-path: |
             main.js
             manifest.json
             styles.css
       - name: Create release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           draft: true
           files: |

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 tag-version-prefix=""
+ignore-scripts=true

--- a/package.json
+++ b/package.json
@@ -16,19 +16,19 @@
 	"author": "Instapaper",
 	"license": "MIT",
 	"devDependencies": {
-		"@eslint/js": "^10.0.1",
-		"@types/mustache": "^4.2.6",
+		"@eslint/js": "10.0.1",
+		"@types/mustache": "4.2.6",
 		"builtin-modules": "5.2.0",
-		"dotenv": "^17.4.2",
+		"dotenv": "17.4.2",
 		"esbuild": "0.28.0",
-		"eslint": "^10.0.2",
-		"eslint-plugin-no-unsanitized": "^4.1.5",
-		"eslint-plugin-security": "^4.0.0",
+		"eslint": "10.0.2",
+		"eslint-plugin-no-unsanitized": "4.1.5",
+		"eslint-plugin-security": "4.0.0",
 		"obsidian": "1.11.0",
-		"typescript": "^6.0.3",
-		"typescript-eslint": "^8.59.0"
+		"typescript": "6.0.3",
+		"typescript-eslint": "8.59.0"
 	},
 	"dependencies": {
-		"mustache": "^4.2.0"
+		"mustache": "4.2.0"
 	}
 }


### PR DESCRIPTION
Apply several mitigations against npm and GitHub Actions supply chain compromise (e.g. Shai-Hulud-style worms that publish malicious package versions and exfiltrate CI secrets via postinstall scripts):

- Set ignore-scripts=true in .npmrc to disable npm lifecycle scripts by default. esbuild's postinstall is not required on modern npm because the platform-specific binary is resolved via optionalDependencies.
- Pin GitHub Actions to commit SHAs in CI and release workflows, with the version tag preserved as a trailing comment for readability.
- Pin exact devDependency and runtime dependency versions in package.json (drop the ^ ranges). The lockfile already pinned by hash; this stops future npm install from silently picking up a patch/minor bump.
- Run `npm audit signatures` after install in both workflows to verify registry-claimed publisher signatures on every installed package.