### PR TITLE
Add durable article identity index and sync resilience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.3.0] - Unreleased
 
+### Added
+
+- Synced notes now store the Instapaper article ID as an article property by default.
+
 ### Changed
 
 - Account connection now uses browser-based OAuth 2 authorization instead of entering credentials directly.
 - Added a "Sync now" button to the settings page.
 - Improved notes folder renaming behavior in settings, and the setting now stays in sync when the folder is renamed elsewhere.
+- Synced notes now keep a persistent article-to-note index so renamed or moved notes are resynced.
+- Deleted synced notes are now treated as intentional removals and are not recreated automatically on the next sync.
 
 ## [1.2.1] - 2026-04-04
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Each synced highlight includes a [block identifier](https://help.obsidian.md/Lin
 
 You can customize which article properties are included in your synced notes. In the plugin settings under **Article properties**, you can set and rename any of these properties:
 
+- **Article ID**: The Instapaper article ID used to keep notes linked across rename and move (default: `instapaperId`)
 - **Title**: The article's title (default: `title`, _disabled_)
 - **Author**: The article's author (default: `author`)
 - **URL**: The article's URL (default: `url`)
@@ -44,6 +45,8 @@ You can customize which article properties are included in your synced notes. In
 - **Source**: A static string value (default: `instapaper`, _disabled_)
 
 Properties are only added to notes when they have values available from Instapaper.
+
+The plugin also keeps an internal index of imported article IDs. This allows synced notes to keep their identity after you rename or move them, and prevents deleted synced notes from being recreated automatically on the next sync.
 
 ### Notes Template
 

--- a/src/frontmatter.ts
+++ b/src/frontmatter.ts
@@ -31,6 +31,14 @@ export async function applyArticleFrontmatter(
     // Property order is preserved for existing files while new files
     // will have properties added in the order below.
     await fileManager.processFrontMatter(file, (frontmatter: Record<string, unknown>) => {
+        if (settings.articleId.enabled && settings.articleId.propertyName) {
+            if (article.id != null) {
+                frontmatter[settings.articleId.propertyName] = article.id;
+            } else {
+                delete frontmatter[settings.articleId.propertyName];
+            }
+        }
+
         if (settings.title.enabled && settings.title.propertyName) {
             if (article.title) {
                 frontmatter[settings.title.propertyName] = article.title;
@@ -116,6 +124,19 @@ export async function applyArticleFrontmatter(
             }
         }
     });
+}
+
+export function getArticleIdPropertyNames(settings: FrontmatterSettings): string[] {
+    const names = new Set<string>();
+
+    if (DEFAULT_SETTINGS.frontmatter.articleId.propertyName) {
+        names.add(DEFAULT_SETTINGS.frontmatter.articleId.propertyName);
+    }
+    if (settings.articleId.propertyName) {
+        names.add(settings.articleId.propertyName);
+    }
+
+    return [...names];
 }
 
 // https://help.obsidian.md/tags#Tag+format

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,8 @@
-import { Keymap, Notice, Plugin, TFolder } from 'obsidian';
+import { Keymap, Notice, Plugin, TFile, TFolder } from 'obsidian';
 import { InstapaperAccount, InstapaperAPI } from './api'
 import { DEFAULT_SETTINGS, InstapaperPluginSettings, InstapaperSettingTab, LEGACY_HIGHLIGHT_TEMPLATE } from './settings'
 import { syncNotes, type SyncNotesOptions } from './notes';
+import { markImportedArticleDeletedByPath, renameImportedArticlePath } from './note-index';
 
 type SyncResult = {
 	notes: number;
@@ -78,6 +79,27 @@ export default class InstapaperPlugin extends Plugin {
 			this.app.vault.on('rename', async (file, oldPath) => {
 				if (file instanceof TFolder && oldPath === this.settings.notesFolder) {
 					await this.saveSettings({ notesFolder: file.path });
+					return;
+				}
+
+				if (file instanceof TFile) {
+					const importedArticles = renameImportedArticlePath(this.settings.importedArticles, oldPath, file.path);
+					if (importedArticles !== this.settings.importedArticles) {
+						await this.saveSettings({ importedArticles });
+					}
+				}
+			})
+		);
+
+		this.registerEvent(
+			this.app.vault.on('delete', async (file) => {
+				if (!(file instanceof TFile)) {
+					return;
+				}
+
+				const importedArticles = markImportedArticleDeletedByPath(this.settings.importedArticles, file.path);
+				if (importedArticles !== this.settings.importedArticles) {
+					await this.saveSettings({ importedArticles });
 				}
 			})
 		);
@@ -196,6 +218,10 @@ export default class InstapaperPlugin extends Plugin {
 		this.settings = {
 			...DEFAULT_SETTINGS,
 			...data,
+			importedArticles: {
+				...DEFAULT_SETTINGS.importedArticles,
+				...data?.importedArticles,
+			},
 			frontmatter: {
 				...DEFAULT_SETTINGS.frontmatter,
 				...data?.frontmatter,
@@ -224,10 +250,18 @@ export default class InstapaperPlugin extends Plugin {
 	// ACCOUNT
 
 	async connectAccount(code: string): Promise<InstapaperAccount> {
+		const previousAccountId = this.settings.importedArticlesAccountId ?? this.settings.account?.id;
 		const { token, account } = await this.api.exchangeCode(code);
 		await this.saveSettings({
 			token: token,
 			account: account,
+			importedArticlesAccountId: account.id,
+			importedArticles: previousAccountId != null && previousAccountId !== account.id
+				? {}
+				: this.settings.importedArticles,
+			notesCursor: previousAccountId != null && previousAccountId !== account.id
+				? 0
+				: this.settings.notesCursor,
 		});
 
 		this.updateSyncInterval();
@@ -270,10 +304,13 @@ export default class InstapaperPlugin extends Plugin {
 		this.log(`synchronizing (${reason}) @ ${cursor}`);
 
 		try {
-			const { cursor: newCursor, count } = await syncNotes(this, token, cursor, options);
+			const { cursor: newCursor, count, indexChanged } = await syncNotes(this, token, cursor, options);
 			result.notes = count;
-			if (control?.saveCursor ?? true) {
-				await this.saveSettings({ notesCursor: newCursor });
+			if ((control?.saveCursor ?? true) || indexChanged) {
+				await this.saveSettings({
+					notesCursor: (control?.saveCursor ?? true) ? newCursor : this.settings.notesCursor,
+					importedArticles: this.settings.importedArticles,
+				});
 			}
 			if (options?.updateHighlightTemplate || ((options?.syncHighlights ?? true) && result.notes > 0)) {
 				await this.saveSettings({ appliedHighlightTemplate: this.settings.highlightTemplate });

--- a/src/note-index.ts
+++ b/src/note-index.ts
@@ -1,0 +1,109 @@
+import { normalizePath } from "obsidian";
+
+export interface ImportedArticleRecord {
+    path: string | null;
+    deleted: boolean;
+}
+
+export type ImportedArticleIndex = Record<string, ImportedArticleRecord>;
+
+function articleKey(articleId: number): string {
+    return String(articleId);
+}
+
+export function getImportedArticle(
+    index: ImportedArticleIndex,
+    articleId: number,
+): ImportedArticleRecord | undefined {
+    return index[articleKey(articleId)];
+}
+
+export function setImportedArticlePath(
+    index: ImportedArticleIndex,
+    articleId: number,
+    path: string,
+): ImportedArticleIndex {
+    const normalizedPath = normalizePath(path);
+    const key = articleKey(articleId);
+    const current = index[key];
+
+    if (current && current.path === normalizedPath && !current.deleted) {
+        return index;
+    }
+
+    return {
+        ...index,
+        [key]: {
+            path: normalizedPath,
+            deleted: false,
+        },
+    };
+}
+
+export function markImportedArticleDeleted(
+    index: ImportedArticleIndex,
+    articleId: number,
+): ImportedArticleIndex {
+    const key = articleKey(articleId);
+    const current = index[key];
+
+    if (current?.deleted && current.path == null) {
+        return index;
+    }
+
+    return {
+        ...index,
+        [key]: {
+            path: null,
+            deleted: true,
+        },
+    };
+}
+
+export function renameImportedArticlePath(
+    index: ImportedArticleIndex,
+    oldPath: string,
+    newPath: string,
+): ImportedArticleIndex {
+    const normalizedOldPath = normalizePath(oldPath);
+    const normalizedNewPath = normalizePath(newPath);
+
+    for (const [articleId, record] of Object.entries(index)) {
+        if (record.path !== normalizedOldPath) {
+            continue;
+        }
+
+        return {
+            ...index,
+            [articleId]: {
+                path: normalizedNewPath,
+                deleted: false,
+            },
+        };
+    }
+
+    return index;
+}
+
+export function markImportedArticleDeletedByPath(
+    index: ImportedArticleIndex,
+    path: string,
+): ImportedArticleIndex {
+    const normalizedPath = normalizePath(path);
+
+    for (const [articleId, record] of Object.entries(index)) {
+        if (record.path !== normalizedPath) {
+            continue;
+        }
+
+        return {
+            ...index,
+            [articleId]: {
+                path: null,
+                deleted: true,
+            },
+        };
+    }
+
+    return index;
+}

--- a/src/notes.ts
+++ b/src/notes.ts
@@ -2,7 +2,8 @@ import { TFile, Vault, normalizePath } from "obsidian";
 import Mustache from "mustache";
 import type InstapaperPlugin from "./main";
 import type { InstapaperAccessToken, InstapaperBookmark, InstapaperHighlight } from "./api";
-import { applyArticleFrontmatter } from "./frontmatter";
+import { applyArticleFrontmatter, getArticleIdPropertyNames } from "./frontmatter";
+import { getImportedArticle, markImportedArticleDeleted, setImportedArticlePath } from "./note-index";
 
 // Disable HTML escaping. We render to Markdown.
 Mustache.escape = (text: string) => text;
@@ -54,6 +55,7 @@ export async function syncNotes(
 ): Promise<{
     cursor: number;
     count: number;
+    indexChanged: boolean;
 }> {
     const opts = {
         createFiles: true,
@@ -69,7 +71,7 @@ export async function syncNotes(
     const folder = normalizePath(plugin.settings.notesFolder);
     if (!await vault.adapter.exists(folder)) {
         if (!opts.createFiles) {
-            return { cursor, count: 0 };
+            return { cursor, count: 0, indexChanged: false };
         }
         await vault.createFolder(folder);
         cursor = 0;
@@ -77,6 +79,7 @@ export async function syncNotes(
 
     let count = 0;
     let errors = 0;
+    let indexChanged = false;
 
     while (true) {
         let highlights: InstapaperHighlight[];
@@ -110,7 +113,9 @@ export async function syncNotes(
             // exist and wasn't created (in which case we skip this article).
             let file: TFile | null;
             try {
-                file = await fileForArticle(article, vault, folder, opts.createFiles);
+                const resolution = await fileForArticle(plugin, article, vault, folder, opts.createFiles);
+                file = resolution.file;
+                indexChanged = indexChanged || resolution.indexChanged;
                 if (!file) continue;
             } catch (e) {
                 plugin.log(`fileForArticle("${article.title}"):`, e);
@@ -126,6 +131,12 @@ export async function syncNotes(
                     fileManager,
                     { removeDisabled: opts.removeDisabledProperties }
                 );
+            }
+
+            const nextIndex = setImportedArticlePath(plugin.settings.importedArticles, article.id, file.path);
+            if (nextIndex !== plugin.settings.importedArticles) {
+                plugin.settings.importedArticles = nextIndex;
+                indexChanged = true;
             }
 
             // Update existing highlights if a template replacement is requested.
@@ -154,15 +165,51 @@ export async function syncNotes(
         }
     }
 
-    return { cursor, count };
+    return { cursor, count, indexChanged };
 }
 
 async function fileForArticle(
+    plugin: InstapaperPlugin,
     article: InstapaperBookmark,
     vault: Vault,
     folder: string,
     create: boolean = true
-): Promise<TFile | null> {
+): Promise<{ file: TFile | null; indexChanged: boolean }> {
+    const indexed = getImportedArticle(plugin.settings.importedArticles, article.id);
+    if (indexed?.deleted) {
+        return { file: null, indexChanged: false };
+    }
+
+    if (indexed?.path) {
+        const indexedFile = vault.getFileByPath(indexed.path);
+        if (indexedFile) {
+            return { file: indexedFile, indexChanged: false };
+        }
+
+        const recoveredFile = findFileByArticleId(plugin, article.id);
+        if (recoveredFile) {
+            plugin.settings.importedArticles = setImportedArticlePath(
+                plugin.settings.importedArticles,
+                article.id,
+                recoveredFile.path,
+            );
+            return { file: recoveredFile, indexChanged: true };
+        }
+
+        plugin.settings.importedArticles = markImportedArticleDeleted(plugin.settings.importedArticles, article.id);
+        return { file: null, indexChanged: true };
+    }
+
+    const recoveredFile = findFileByArticleId(plugin, article.id);
+    if (recoveredFile) {
+        plugin.settings.importedArticles = setImportedArticlePath(
+            plugin.settings.importedArticles,
+            article.id,
+            recoveredFile.path,
+        );
+        return { file: recoveredFile, indexChanged: true };
+    }
+
     // Use a sanitized version of the article's title for our filename.
     let name = (article.title ?? '').replace(/[\\/:<>?|*"]/gm, '').substring(0, 250).trim();
     if (!name) {
@@ -172,7 +219,50 @@ async function fileForArticle(
     const path = normalizePath(`${folder}/${name}.md`);
     const file = vault.getFileByPath(path);
 
-    return file || (create ? vault.create(path, '') : null);
+    if (file) {
+        plugin.settings.importedArticles = setImportedArticlePath(plugin.settings.importedArticles, article.id, file.path);
+        return { file, indexChanged: true };
+    }
+
+    if (!create) {
+        return { file: null, indexChanged: false };
+    }
+
+    const created = await vault.create(path, '');
+    plugin.settings.importedArticles = setImportedArticlePath(plugin.settings.importedArticles, article.id, created.path);
+    return { file: created, indexChanged: true };
+}
+
+function findFileByArticleId(plugin: InstapaperPlugin, articleId: number): TFile | null {
+    const propertyNames = getArticleIdPropertyNames(plugin.settings.frontmatter);
+
+    for (const file of plugin.app.vault.getMarkdownFiles()) {
+        const frontmatter = plugin.app.metadataCache.getFileCache(file)?.frontmatter;
+        if (!frontmatter) {
+            continue;
+        }
+
+        for (const propertyName of propertyNames) {
+            if (parseArticleId(frontmatter[propertyName]) === articleId) {
+                return file;
+            }
+        }
+    }
+
+    return null;
+}
+
+function parseArticleId(value: unknown): number | null {
+    if (typeof value === 'number' && Number.isInteger(value)) {
+        return value;
+    }
+
+    if (typeof value === 'string' && value.trim()) {
+        const parsed = Number.parseInt(value, 10);
+        return Number.isInteger(parsed) ? parsed : null;
+    }
+
+    return null;
 }
 
 function linkForHighlight(highlight: InstapaperHighlight): string {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,6 +1,7 @@
 import { App, ButtonComponent, Platform, PluginSettingTab, Setting, SettingGroup, TextAreaComponent, TextComponent, TFolder, normalizePath } from "obsidian";
 import InstapaperPlugin from "./main";
 import type { InstapaperAccessToken, InstapaperAccount } from "./api";
+import type { ImportedArticleIndex } from "./note-index";
 
 export interface FrontmatterField {
     enabled: boolean;
@@ -12,6 +13,7 @@ export interface FrontmatterValueField extends FrontmatterField {
 }
 
 export interface FrontmatterSettings {
+    articleId: FrontmatterField;
     url: FrontmatterField;
     title: FrontmatterField;
     date: FrontmatterField;
@@ -37,10 +39,12 @@ const DEFAULT_HIGHLIGHT_TEMPLATE = `> {{text}} {{blockId}}
 export interface InstapaperPluginSettings {
     token?: InstapaperAccessToken;
     account?: InstapaperAccount;
+    importedArticlesAccountId?: number;
     syncFrequency: number;
     syncOnStart: boolean;
     notesFolder: string;
     notesCursor: number;
+    importedArticles: ImportedArticleIndex;
     frontmatter: FrontmatterSettings;
     highlightTemplate: string;
     appliedHighlightTemplate?: string;
@@ -52,7 +56,9 @@ export const DEFAULT_SETTINGS = {
     syncOnStart: true,
     notesFolder: 'Instapaper Notes',
     notesCursor: 0,
+    importedArticles: {},
     frontmatter: {
+        articleId: { enabled: true, propertyName: 'instapaperId' },
         url: { enabled: true, propertyName: 'url' },
         title: { enabled: false, propertyName: 'title' },
         date: { enabled: true, propertyName: 'date' },
@@ -394,6 +400,7 @@ export class InstapaperSettingTab extends PluginSettingTab {
             });
         };
 
+        addField("Article ID", "The Instapaper article ID used to keep notes linked across rename and move", "articleId");
         addField("Title", "The article's title", "title");
         addField("Author", "The article's author", "author");
         addField("URL", "The article's URL", "url");


### PR DESCRIPTION
## Summary
This PR makes Instapaper note identity durable across rename/move operations and prevents unintended recreation of intentionally deleted synced notes.

## What Changed
- Added persistent article identity tracking via article ID.
- Added internal imported-article index and helpers for path updates and tombstones.
- Updated sync resolution to:
  - Prefer indexed note path for each article.
  - Recover by frontmatter article ID when paths change.
  - Respect deleted tombstones to avoid recreating intentionally removed notes.
- Added/updated settings to support:
  - Article ID frontmatter field configuration.
  - Imported-article index persistence and account-scoped resets.
- Added vault event handling to keep index in sync on rename/delete.
- Updated docs and changelog for article identity/index behavior.

## Why
Previously, note mapping relied on filename/title heuristics, which could break after manual rename/move and could recreate deleted notes. This PR makes note linkage stable and predictable.

## Testing
- Sync creates notes normally.
- Rename a synced note, run sync again:
  - Existing note is reused.
  - No duplicate note created.
- Move a synced note, run sync again:
  - Existing moved note is reused.
- Delete a synced note, run sync again:
  - Note is not recreated automatically.
- Account switch clears account-scoped imported index behavior correctly.