### PR TITLE
Add configurable emoji stripping for note title filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Account connection now uses browser-based OAuth 2 authorization instead of entering credentials directly.
 - Added a "Sync now" button to the settings page.
 - Improved notes folder renaming behavior in settings, and the setting now stays in sync when the folder is renamed elsewhere.
+- New notes now strip emoji characters from article titles when generating filenames.
 
 ## [1.2.1] - 2026-04-04
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ You can customize which article properties are included in your synced notes. In
 
 Properties are only added to notes when they have values available from Instapaper.
 
+When creating new notes, the plugin removes emoji characters from article titles before generating the note filename. Existing notes keep their current names.
+
 ### Notes Template
 
 You can customize how highlights appear in your notes using a [Mustache](https://mustache.github.io/) template. In the plugin settings under **Notes → Template**, you can use the following variables:

--- a/src/notes.ts
+++ b/src/notes.ts
@@ -110,7 +110,13 @@ export async function syncNotes(
             // exist and wasn't created (in which case we skip this article).
             let file: TFile | null;
             try {
-                file = await fileForArticle(article, vault, folder, opts.createFiles);
+                file = await fileForArticle(
+                    article,
+                    vault,
+                    folder,
+                    opts.createFiles,
+                    plugin.settings.stripEmojisFromTitle,
+                );
                 if (!file) continue;
             } catch (e) {
                 plugin.log(`fileForArticle("${article.title}"):`, e);
@@ -161,18 +167,44 @@ async function fileForArticle(
     article: InstapaperBookmark,
     vault: Vault,
     folder: string,
-    create: boolean = true
+    create: boolean = true,
+    stripEmojisFromTitle: boolean = true,
 ): Promise<TFile | null> {
-    // Use a sanitized version of the article's title for our filename.
-    let name = (article.title ?? '').replace(/[\\/:<>?|*"]/gm, '').substring(0, 250).trim();
-    if (!name) {
-        name = `Untitled-${article.id}`;
+    const preferredName = fileNameForArticle(article, { stripEmoji: stripEmojisFromTitle });
+    const preferredPath = normalizePath(`${folder}/${preferredName}.md`);
+    const preferredFile = vault.getFileByPath(preferredPath);
+
+    // Fallback to the alternate naming mode so changing this setting does not
+    // create duplicate notes for the same article.
+    const alternateName = fileNameForArticle(article, { stripEmoji: !stripEmojisFromTitle });
+    const alternatePath = normalizePath(`${folder}/${alternateName}.md`);
+    const alternateFile = preferredPath === alternatePath
+        ? null
+        : vault.getFileByPath(alternatePath);
+
+    const file = preferredFile ?? alternateFile;
+    return file || (create ? vault.create(preferredPath, '') : null);
+}
+
+function fileNameForArticle(
+    article: InstapaperBookmark,
+    options?: { stripEmoji?: boolean },
+): string {
+    let name = article.title ?? '';
+
+    if (options?.stripEmoji ?? false) {
+        name = name
+            .replace(/\p{Extended_Pictographic}/gu, '')
+            .replace(/[\u200D\uFE0F]/g, '');
     }
 
-    const path = normalizePath(`${folder}/${name}.md`);
-    const file = vault.getFileByPath(path);
+    name = name
+        .replace(/[\\/:<>?|*"]/gm, '')
+        .replace(/\s+/g, ' ')
+        .substring(0, 250)
+        .trim();
 
-    return file || (create ? vault.create(path, '') : null);
+    return name || `Untitled-${article.id}`;
 }
 
 function linkForHighlight(highlight: InstapaperHighlight): string {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -39,6 +39,7 @@ export interface InstapaperPluginSettings {
     account?: InstapaperAccount;
     syncFrequency: number;
     syncOnStart: boolean;
+    stripEmojisFromTitle: boolean;
     notesFolder: string;
     notesCursor: number;
     frontmatter: FrontmatterSettings;
@@ -50,6 +51,7 @@ export interface InstapaperPluginSettings {
 export const DEFAULT_SETTINGS = {
     syncFrequency: 0,
     syncOnStart: true,
+    stripEmojisFromTitle: true,
     notesFolder: 'Instapaper Notes',
     notesCursor: 0,
     frontmatter: {
@@ -328,6 +330,18 @@ export class InstapaperSettingTab extends PluginSettingTab {
 
         group.addSetting((setting) => {
             setting.setDesc('Configure which article properties to add. Properties are only added when available.');
+        });
+
+        group.addSetting((setting) => {
+            setting
+                .setName('Strip emojis from note titles')
+                .setDesc('When enabled, emoji characters are removed from article titles before generating note filenames.')
+                .addToggle((toggle) => {
+                    toggle.setValue(this.plugin.settings.stripEmojisFromTitle);
+                    toggle.onChange(async (value) => {
+                        await this.plugin.saveSettings({ stripEmojisFromTitle: value });
+                    });
+                });
         });
 
         const addField = (


### PR DESCRIPTION
## Summary
This PR adds a settings toggle to enable/disable stripping emoji characters from article titles when generating note filenames.

## What Changed
- Added setting:
  - "Strip emojis from note titles" under Article properties.
- Added persisted setting value with default enabled.
- Updated filename generation logic to use this setting.
- Added fallback behavior so toggling the setting does not create duplicate notes if an existing note already matches the alternate naming mode.
- Updated docs and changelog for this feature.

## Why
Users may want cleaner filesystem-friendly filenames without emoji, while others may prefer original title fidelity. This setting supports both workflows.

## Testing
- With toggle ON:
  - New notes generated from emoji-containing titles have emoji removed in filename.
- With toggle OFF:
  - New notes preserve emoji in filename (subject to existing filename sanitization rules).
- Switch toggle after notes already exist:
  - Existing note is reused when possible; no duplicate created.
- Build and sync run successfully.