### PR TITLE
Add configurable URL type for article property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.3.0] - Unreleased
 
+### Added
+
+- Added a URL type dropdown under **Article properties → URL** to choose between Instapaper app links and web links for the URL property.
+
 ### Changed
 
 - Account connection now uses browser-based OAuth 2 authorization instead of entering credentials directly.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ You can customize which article properties are included in your synced notes. In
 - **Tags**: Tags from Instapaper (default: `tags`)
 - **Source**: A static string value (default: `instapaper`, _disabled_)
 
+For the **URL** property, you can choose the URL format from a dropdown directly below the URL setting:
+
+- **Instapaper app** (default): `instapaper-private://x-callback-url/open?bookmark_id={id}`
+- **Web**: `https://instapaper.com/read/{id}`
+
 Properties are only added to notes when they have values available from Instapaper.
 
 ### Notes Template

--- a/src/frontmatter.ts
+++ b/src/frontmatter.ts
@@ -1,6 +1,6 @@
 import { TFile, FileManager, moment } from "obsidian";
 import type { InstapaperBookmark, InstapaperTag } from "./api";
-import type { FrontmatterField, FrontmatterSettings } from "./settings";
+import type { ArticleUrlType, FrontmatterField, FrontmatterSettings } from "./settings";
 import { DEFAULT_SETTINGS } from "./settings";
 
 /**
@@ -26,7 +26,7 @@ export async function applyArticleFrontmatter(
     article: Partial<InstapaperBookmark>,
     settings: FrontmatterSettings,
     fileManager: FileManager,
-    options?: { removeDisabled?: boolean }
+    options?: { removeDisabled?: boolean; articleUrlType?: ArticleUrlType }
 ): Promise<void> {
     // Property order is preserved for existing files while new files
     // will have properties added in the order below.
@@ -48,8 +48,13 @@ export async function applyArticleFrontmatter(
         }
 
         if (settings.url.enabled && settings.url.propertyName) {
-            if (article.url) {
-                frontmatter[settings.url.propertyName] = article.url;
+            const url = getConfiguredArticleUrl(
+                article,
+                options?.articleUrlType ?? DEFAULT_SETTINGS.articleUrlType,
+            );
+
+            if (url) {
+                frontmatter[settings.url.propertyName] = url;
             } else {
                 delete frontmatter[settings.url.propertyName];
             }
@@ -134,4 +139,16 @@ function normalizeTag(tag: InstapaperTag): string {
 // https://help.obsidian.md/properties#Date
 function formatTimestamp(timestamp: number): string {
     return moment.unix(timestamp).format("YYYY-MM-DD");
+}
+
+function getConfiguredArticleUrl(article: Partial<InstapaperBookmark>, articleUrlType: ArticleUrlType): string | null {
+    if (article.id != null) {
+        if (articleUrlType === 'web') {
+            return `https://instapaper.com/read/${article.id}`;
+        }
+
+        return `instapaper-private://x-callback-url/open?bookmark_id=${article.id}`;
+    }
+
+    return article.url ?? null;
 }

--- a/src/notes.ts
+++ b/src/notes.ts
@@ -124,7 +124,10 @@ export async function syncNotes(
                     article,
                     plugin.settings.frontmatter,
                     fileManager,
-                    { removeDisabled: opts.removeDisabledProperties }
+                    {
+                        removeDisabled: opts.removeDisabledProperties,
+                        articleUrlType: plugin.settings.articleUrlType,
+                    }
                 );
             }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -21,6 +21,8 @@ export interface FrontmatterSettings {
     source: FrontmatterValueField;
 }
 
+export type ArticleUrlType = 'instapaper-private' | 'web';
+
 // The highlight template used before template customization was introduced.
 export const LEGACY_HIGHLIGHT_TEMPLATE = `> {{text}} [↗]({{link}})
 {{#note}}
@@ -37,6 +39,7 @@ const DEFAULT_HIGHLIGHT_TEMPLATE = `> {{text}} {{blockId}}
 export interface InstapaperPluginSettings {
     token?: InstapaperAccessToken;
     account?: InstapaperAccount;
+    articleUrlType: ArticleUrlType;
     syncFrequency: number;
     syncOnStart: boolean;
     notesFolder: string;
@@ -48,6 +51,7 @@ export interface InstapaperPluginSettings {
 
 // Note! This needs to be kept in sync with the deep merge in loadSettings().
 export const DEFAULT_SETTINGS = {
+    articleUrlType: 'instapaper-private' as ArticleUrlType,
     syncFrequency: 0,
     syncOnStart: true,
     notesFolder: 'Instapaper Notes',
@@ -397,6 +401,20 @@ export class InstapaperSettingTab extends PluginSettingTab {
         addField("Title", "The article's title", "title");
         addField("Author", "The article's author", "author");
         addField("URL", "The article's URL", "url");
+        group.addSetting((setting) => {
+            setting
+                .setName('URL type')
+                .setDesc('Choose the URL format written to the URL property.')
+                .addDropdown((dropdown) => {
+                    dropdown
+                        .addOption('instapaper-private', 'Instapaper app (instapaper-private://)')
+                        .addOption('web', 'Web (https://instapaper.com/read/...)')
+                        .setValue(this.plugin.settings.articleUrlType)
+                        .onChange(async (value) => {
+                            await this.plugin.saveSettings({ articleUrlType: value as ArticleUrlType });
+                        });
+                });
+        });
         addField("Publish date", "When the article was published", "pubdate");
         addField("Saved date", "When you saved the article to Instapaper", "date");
         addField("Tags", "Tags from Instapaper", "tags");


### PR DESCRIPTION
## Summary
This PR adds a URL type selector under Article properties -> URL, allowing users to choose which URL format is written into note frontmatter.

## What Changed
- Added setting:
  - "URL type" dropdown directly under the URL article property setting.
- Added options:
  - Instapaper app link (default): `instapaper-private://x-callback-url/open?bookmark_id={id}`
  - Web link: `https://instapaper.com/read/{id}`
- Updated frontmatter URL writing logic to emit the selected URL format.
- Updated sync/frontmatter call path to pass and apply URL type setting.
- Updated docs and changelog for this feature.

## Why
Some users prefer opening links in the Instapaper app, while others prefer browser/web URLs. This setting makes the URL property behavior explicit and configurable.

## Testing
- Default setting writes instapaper-private URL format.
- Switching to Web writes https://instapaper.com/read/{id}.
- Existing sync behavior remains unchanged apart from URL output format.
- Build and sync run successfully.