### PR TITLE
dependabot: ignore typescript-eslint minor updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,7 @@ updates:
           - version-update:semver-patch
       - dependency-name: "typescript-eslint"
         update-types:
+          - version-update:semver-minor
           - version-update:semver-patch
       - dependency-name: "esbuild"
         update-types:


### PR DESCRIPTION
typescript-eslint ships minor releases frequently, generating a steady stream of update PRs. Previously only patch updates were ignored, so every minor release opened a PR.

Ignore minor updates as well, matching the treatment already given to eslint itself. Major updates still open PRs, and security updates are unaffected because Dependabot exempts them from the ignore list.